### PR TITLE
https://github.com/temenostech/IRIS/issues/183

### DIFF
--- a/interaction-core/src/main/java/com/temenos/interaction/core/rim/HTTPHypermediaRIM.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/rim/HTTPHypermediaRIM.java
@@ -807,8 +807,6 @@ public class HTTPHypermediaRIM implements HTTPResourceInteractionModel {
 					action, 
 					(EntityResource<?>)currentResource, 
 					config);
-        	RESTResource resource = (RESTResource) ((GenericEntity<?>)response.getEntity()).getEntity();
-        	resource.setEntityName(targetState.getEntityName());
         	
 			return response;
 			


### PR DESCRIPTION
When there are chained auto transitions e.g. a --> b --> c the iris output reflects the target resources data except for the term attribute of the category element; the term attribute reflects the term of the first auto transition i.e. b in the example above