### PR TITLE
Move IRIS-*.properties files into META-INF

### DIFF
--- a/interaction-commands-authorization/pom.xml
+++ b/interaction-commands-authorization/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.temenos.interaction</groupId>
 		<artifactId>interaction-parent</artifactId>
-		<version>0.6.1</version>
+		<version>0.6.2-SNAPSHOT</version>
 		<relativePath>../interaction-parent/pom.xml</relativePath>
 	</parent>
 
@@ -19,7 +19,7 @@
 		<dependency>
 			<groupId>com.temenos.interaction</groupId>
 			<artifactId>interaction-core</artifactId>
-			<version>0.6.1</version><!--$NO-MVN-MAN-VER$-->
+			<version>0.6.2-SNAPSHOT</version><!--$NO-MVN-MAN-VER$-->
 		</dependency>
 
         <!-- SPRING dependencies-->

--- a/interaction-commands-mule/pom.xml
+++ b/interaction-commands-mule/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.temenos.interaction</groupId>
         <artifactId>interaction-parent</artifactId>
-        <version>0.6.1</version>
+        <version>0.6.2-SNAPSHOT</version>
         <relativePath>../interaction-parent/pom.xml</relativePath>
     </parent>
 

--- a/interaction-commands-odata-bridge/pom.xml
+++ b/interaction-commands-odata-bridge/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.temenos.interaction</groupId>
 		<artifactId>interaction-parent</artifactId>
-		<version>0.6.1</version>
+		<version>0.6.2-SNAPSHOT</version>
 		<relativePath>../interaction-parent/pom.xml</relativePath>
 	</parent>
 

--- a/interaction-commands-odata/pom.xml
+++ b/interaction-commands-odata/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.temenos.interaction</groupId>
 		<artifactId>interaction-parent</artifactId>
-		<version>0.6.1</version>
+		<version>0.6.2-SNAPSHOT</version>
 		<relativePath>../interaction-parent/pom.xml</relativePath>
 	</parent>
 

--- a/interaction-commands-solr/pom.xml
+++ b/interaction-commands-solr/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.temenos.interaction</groupId>
         <artifactId>interaction-parent</artifactId>
-        <version>0.6.1</version>
+        <version>0.6.2-SNAPSHOT</version>
         <relativePath>../interaction-parent/pom.xml</relativePath>
     </parent>
 
@@ -19,7 +19,7 @@
    		<dependency>
 			<groupId>com.temenos.interaction</groupId>
 			<artifactId>interaction-core</artifactId>
-			<version>0.6.1</version><!--$NO-MVN-MAN-VER$-->
+			<version>0.6.2-SNAPSHOT</version><!--$NO-MVN-MAN-VER$-->
 		</dependency>
 
 		<!-- SOLR dependencies -->
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>com.temenos.interaction</groupId>
             <artifactId>interaction-commands-authorization</artifactId>
-            <version>0.6.1</version>
+            <version>0.6.2-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/interaction-commands-webhook/pom.xml
+++ b/interaction-commands-webhook/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.temenos.interaction</groupId>
 		<artifactId>interaction-parent</artifactId>
-		<version>0.6.1</version>
+		<version>0.6.2-SNAPSHOT</version>
 		<relativePath>../interaction-parent/pom.xml</relativePath>
 	</parent>
 

--- a/interaction-core/pom.xml
+++ b/interaction-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.temenos.interaction</groupId>
 		<artifactId>interaction-parent</artifactId>
-		<version>0.6.1</version>
+		<version>0.6.2-SNAPSHOT</version>
 		<relativePath>../interaction-parent/pom.xml</relativePath>
 	</parent>
 

--- a/interaction-dsl/com.temenos.interaction.rimdsl.generator/pom.xml
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.generator/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>com.temenos.interaction</groupId>
 		<artifactId>com.temenos.interaction.rimdsl.parent</artifactId>
 		<!-- You should change this and the MANIFEST.MF to your versioning scheme -->
-		<version>0.6.1</version>
+		<version>0.6.2-SNAPSHOT</version>
 		<relativePath>../com.temenos.interaction.rimdsl.parent/pom.xml</relativePath>
 	</parent>
 	<artifactId>com.temenos.interaction.rimdsl.generator</artifactId>

--- a/interaction-dsl/com.temenos.interaction.rimdsl.parent/pom.xml
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.parent/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.temenos.interaction</groupId>
 	<artifactId>com.temenos.interaction.rimdsl.parent</artifactId>
 	<!-- You should change this and the MANIFEST.MF to your versioning scheme -->
-	<version>0.6.1</version>
+	<version>0.6.2-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>com.temenos.interaction.rimdsl.RimDsl - Parent</name>
 

--- a/interaction-dsl/com.temenos.interaction.rimdsl.sdk/feature.xml
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.sdk/feature.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature id="com.temenos.interaction.rimdsl.sdk"
 	label="RimDSL SDK Feature "
-	version="0.6.1">
+	version="0.6.2.qualifier">
 	<plugin
 			id="com.temenos.interaction.rimdsl"
 			download-size="0"

--- a/interaction-dsl/com.temenos.interaction.rimdsl.sdk/pom.xml
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.sdk/pom.xml
@@ -7,7 +7,7 @@
 		<groupId>com.temenos.interaction</groupId>
 		<artifactId>com.temenos.interaction.rimdsl.parent</artifactId>
 		<!-- You should change this and the MANIFEST.MF to your versioning scheme -->
-		<version>0.6.1</version>
+		<version>0.6.2-SNAPSHOT</version>
 		<relativePath>../com.temenos.interaction.rimdsl.parent/pom.xml</relativePath>
 	</parent>
 

--- a/interaction-dsl/com.temenos.interaction.rimdsl.site/category.xml
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.site/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/com.temenos.interaction.rimdsl.sdk_0.6.1.jar" id="com.temenos.interaction.rimdsl.sdk" version="0.6.1">
+   <feature url="features/com.temenos.interaction.rimdsl.sdk_0.6.2.qualifier.jar" id="com.temenos.interaction.rimdsl.sdk" version="0.6.2.qualifier">
       <category name="IRIS_RIM_DSL"/>
    </feature>
    <category-def name="IRIS_RIM_DSL" label="IRIS Resource Interaction Model DSL">

--- a/interaction-dsl/com.temenos.interaction.rimdsl.site/pom.xml
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.site/pom.xml
@@ -7,7 +7,7 @@
 		<groupId>com.temenos.interaction</groupId>
 		<artifactId>com.temenos.interaction.rimdsl.parent</artifactId>
 		<!-- You should change this and the MANIFEST.MF to your versioning scheme -->
-		<version>0.6.1</version>
+		<version>0.6.2-SNAPSHOT</version>
 		<relativePath>../com.temenos.interaction.rimdsl.parent/pom.xml</relativePath>
 	</parent>
 

--- a/interaction-dsl/com.temenos.interaction.rimdsl.tests/META-INF/MANIFEST.MF
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: com.temenos.interaction.rimdsl.tests
 Bundle-Vendor: IRIS
-Bundle-Version: 0.6.1
+Bundle-Version: 0.6.2.qualifier
 Bundle-SymbolicName: com.temenos.interaction.rimdsl.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: com.temenos.interaction.rimdsl,

--- a/interaction-dsl/com.temenos.interaction.rimdsl.tests/pom.xml
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.tests/pom.xml
@@ -7,7 +7,7 @@
 		<groupId>com.temenos.interaction</groupId>
 		<artifactId>com.temenos.interaction.rimdsl.parent</artifactId>
 		<!-- You should change this and the MANIFEST.MF to your versioning scheme -->
-		<version>0.6.1</version>
+		<version>0.6.2-SNAPSHOT</version>
 		<relativePath>../com.temenos.interaction.rimdsl.parent/pom.xml</relativePath>
 	</parent>
 

--- a/interaction-dsl/com.temenos.interaction.rimdsl.tests/src/com/temenos/interaction/rimdsl/GeneratorSpringPRDTest.java
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.tests/src/com/temenos/interaction/rimdsl/GeneratorSpringPRDTest.java
@@ -129,7 +129,7 @@ public class GeneratorSpringPRDTest {
 		Map<String, Object> allFiles = fsa.getAllFiles();
 		assertEquals(2, fsa.getAllFiles().size());
 		assertTrue(allFiles.containsKey(IFileSystemAccess.DEFAULT_OUTPUT + "IRIS-Test-PRD.xml"));
-		assertTrue(allFiles.containsKey(IFileSystemAccess.DEFAULT_OUTPUT + "IRIS-Test.properties"));
+		assertTrue(allFiles.containsKey(IFileSystemAccess.DEFAULT_OUTPUT + "META-INF/IRIS-Test.properties"));
 	}
 
 	/**
@@ -146,7 +146,7 @@ public class GeneratorSpringPRDTest {
 		underTest.doGenerate(model.eResource(), fsa);
 
 		Map<String, Object> allFiles = fsa.getAllFiles();
-		String output = allFiles.get(IFileSystemAccess.DEFAULT_OUTPUT + "IRIS-Test.properties").toString();
+		String output = allFiles.get(IFileSystemAccess.DEFAULT_OUTPUT + "META-INF/IRIS-Test.properties").toString();
 		assertTrue(output.contains("Test-A=GET /A"));
 	}
 
@@ -174,7 +174,7 @@ public class GeneratorSpringPRDTest {
 		underTest.doGenerate(model.eResource(), fsa);
 
 		Map<String, Object> allFiles = fsa.getAllFiles();
-		String output = allFiles.get(IFileSystemAccess.DEFAULT_OUTPUT + "IRIS-Test.properties").toString();
+		String output = allFiles.get(IFileSystemAccess.DEFAULT_OUTPUT + "META-INF/IRIS-Test.properties").toString();
 		assertTrue(output.contains("Test-A=GET,POST /A"));
 	}
 

--- a/interaction-dsl/com.temenos.interaction.rimdsl.ui/META-INF/MANIFEST.MF
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: com.temenos.interaction.rimdsl.ui
 Bundle-Vendor: IRIS
-Bundle-Version: 0.6.1
+Bundle-Version: 0.6.2.qualifier
 Bundle-SymbolicName: com.temenos.interaction.rimdsl.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: com.temenos.interaction.rimdsl;visibility:=reexport,

--- a/interaction-dsl/com.temenos.interaction.rimdsl.ui/pom.xml
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.ui/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>com.temenos.interaction</groupId>
 		<artifactId>com.temenos.interaction.rimdsl.parent</artifactId>
 		<!-- You should change this and the MANIFEST.MF to your versioning scheme -->
-		<version>0.6.1</version>
+		<version>0.6.2-SNAPSHOT</version>
 		<relativePath>../com.temenos.interaction.rimdsl.parent/pom.xml</relativePath>
 	</parent>
 	<artifactId>com.temenos.interaction.rimdsl.ui</artifactId>

--- a/interaction-dsl/com.temenos.interaction.rimdsl.visualisation/META-INF/MANIFEST.MF
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.visualisation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: com.temenos.interaction.rimdsl.visualisation
 Bundle-SymbolicName: com.temenos.interaction.rimdsl.visualisation;singleton:=true
-Bundle-Version: 0.6.1
+Bundle-Version: 0.6.2.qualifier
 Bundle-Activator: com.temenos.interaction.rimdsl.visualisation.Activator
 Bundle-Vendor: IRIS
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/interaction-dsl/com.temenos.interaction.rimdsl.visualisation/pom.xml
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.visualisation/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>com.temenos.interaction</groupId>
 		<artifactId>com.temenos.interaction.rimdsl.parent</artifactId>
 		<!-- You should change this and the MANIFEST.MF to your versioning scheme -->
-		<version>0.6.1</version>
+		<version>0.6.2-SNAPSHOT</version>
 		<relativePath>../com.temenos.interaction.rimdsl.parent/pom.xml</relativePath>
 	</parent>
 	<artifactId>com.temenos.interaction.rimdsl.visualisation</artifactId>

--- a/interaction-dsl/com.temenos.interaction.rimdsl/META-INF/MANIFEST.MF
+++ b/interaction-dsl/com.temenos.interaction.rimdsl/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ xManifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: com.temenos.interaction.rimdsl
 Bundle-Vendor: IRIS
-Bundle-Version: 0.6.1
+Bundle-Version: 0.6.2.qualifier
 Bundle-SymbolicName: com.temenos.interaction.rimdsl; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext;bundle-version="[2.5,2.8)";visibility:=reexport,

--- a/interaction-dsl/com.temenos.interaction.rimdsl/pom.xml
+++ b/interaction-dsl/com.temenos.interaction.rimdsl/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>com.temenos.interaction</groupId>
 		<artifactId>com.temenos.interaction.rimdsl.parent</artifactId>
 		<!-- You should change this and the MANIFEST.MF to your versioning scheme -->
-		<version>0.6.1</version>
+		<version>0.6.2-SNAPSHOT</version>
 		<relativePath>../com.temenos.interaction.rimdsl.parent/pom.xml</relativePath>
 	</parent>
 	<artifactId>com.temenos.interaction.rimdsl</artifactId>

--- a/interaction-dsl/com.temenos.interaction.rimdsl/src/com/temenos/interaction/rimdsl/generator/RIMDslGeneratorSpringPRD.xtend
+++ b/interaction-dsl/com.temenos.interaction.rimdsl/src/com/temenos/interaction/rimdsl/generator/RIMDslGeneratorSpringPRD.xtend
@@ -48,7 +48,7 @@ class RIMDslGeneratorSpringPRD implements IGenerator {
         
         fsa.generateFile("IRIS-" + rimName + "-PRD.xml", toSpringXML(rim))
 
-        fsa.generateFile("IRIS-" + rimName + ".properties", toBeanMap(rim))
+        fsa.generateFile("META-INF/IRIS-" + rimName + ".properties", toBeanMap(rim))
 	}
 
 	

--- a/interaction-dsl/interaction-springdsl/pom.xml
+++ b/interaction-dsl/interaction-springdsl/pom.xml
@@ -5,7 +5,7 @@
   	<parent>
 		<groupId>com.temenos.interaction</groupId>
 		<artifactId>interaction-parent</artifactId>
-		<version>0.6.1</version>
+		<version>0.6.2-SNAPSHOT</version>
 		<relativePath>../../interaction-parent/pom.xml</relativePath>
 	</parent>
 

--- a/interaction-dsl/interaction-springdsl/src/main/resources/IRIS-SpringDSL-main.xml
+++ b/interaction-dsl/interaction-springdsl/src/main/resources/IRIS-SpringDSL-main.xml
@@ -38,6 +38,7 @@
   		<property name="locations">
     		<list>
       			<value>classpath*:IRIS-*.properties</value>
+      			<value>classpath*:/META-INF/IRIS-*.properties</value>
     		</list>
   		</property>
 	</bean>

--- a/interaction-dynamic-loader/pom.xml
+++ b/interaction-dynamic-loader/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   	<parent>
 		<groupId>com.temenos.interaction</groupId>
 		<artifactId>interaction-parent</artifactId>
-		<version>0.6.1</version>
+		<version>0.6.2-SNAPSHOT</version>
 		<relativePath>../interaction-parent/pom.xml</relativePath>
 	</parent>
 

--- a/interaction-examples/interaction-hateoas-banking/pom.xml
+++ b/interaction-examples/interaction-hateoas-banking/pom.xml
@@ -5,7 +5,7 @@
   <parent>
 	<groupId>com.temenos.interaction</groupId>
 	<artifactId>interaction-parent</artifactId>
-	<version>0.6.1</version>
+	<version>0.6.2-SNAPSHOT</version>
 	<relativePath>../../interaction-parent/pom.xml</relativePath>
   </parent>
 
@@ -150,7 +150,7 @@
     									interaction-sdk-rim-plugin
     								</artifactId>
     								<versionRange>
-    									[0.6.1,)
+    									[0.6.2-SNAPSHOT,)
     								</versionRange>
     								<goals>
     									<goal>rim-generate</goal>

--- a/interaction-examples/interaction-hateoas-dynamic/pom.xml
+++ b/interaction-examples/interaction-hateoas-dynamic/pom.xml
@@ -5,7 +5,7 @@
   <parent>
 	<groupId>com.temenos.interaction</groupId>
 	<artifactId>interaction-parent</artifactId>
-	<version>0.6.1</version>
+	<version>0.6.2-SNAPSHOT</version>
 	<relativePath>../../interaction-parent/pom.xml</relativePath>
   </parent>
 
@@ -169,7 +169,7 @@
     									interaction-sdk-plugin
     								</artifactId>
     								<versionRange>
-    									[0.6.1,)
+    									[0.6.2-SNAPSHOT,)
     								</versionRange>
     								<goals>
     									<goal>rim-generate</goal>
@@ -188,7 +188,7 @@
     									interaction-sdk-rim-plugin
     								</artifactId>
     								<versionRange>
-    									[0.6.1,)
+    									[0.6.2-SNAPSHOT,)
     								</versionRange>
     								<goals>
     									<goal>rim-generate</goal>

--- a/interaction-examples/interaction-hateoas-restbucks/pom.xml
+++ b/interaction-examples/interaction-hateoas-restbucks/pom.xml
@@ -25,7 +25,7 @@
   <parent>
 	<groupId>com.temenos.interaction</groupId>
 	<artifactId>interaction-parent</artifactId>
-	<version>0.6.1</version>
+	<version>0.6.2-SNAPSHOT</version>
 	<relativePath>../../interaction-parent/pom.xml</relativePath>
   </parent>
 
@@ -65,7 +65,7 @@
       <plugin>
         <groupId>com.temenos.interaction</groupId>
         <artifactId>interaction-sdk-plugin</artifactId>
-        <version>0.6.1</version>
+        <version>0.6.2-SNAPSHOT</version>
         <configuration>
           <edmxFile>${basedir}/service.edmx</edmxFile>
           <srcTargetDirectory>${basedir}/src/main/java</srcTargetDirectory>
@@ -76,7 +76,7 @@
       <plugin>
         <groupId>com.temenos.interaction</groupId>
         <artifactId>interaction-sdk-rim-plugin</artifactId>
-        <version>0.6.1</version>
+        <version>0.6.2-SNAPSHOT</version>
         <executions>
           <!-- Generate the Java source from the RIM during each build -->
           <execution>
@@ -194,7 +194,7 @@
     									interaction-sdk-rim-plugin
     								</artifactId>
     								<versionRange>
-    									[0.6.1,)
+    									[0.6.2-SNAPSHOT,)
     								</versionRange>
     								<goals>
     									<goal>rim-generate</goal>

--- a/interaction-examples/interaction-hateoas-simple/pom.xml
+++ b/interaction-examples/interaction-hateoas-simple/pom.xml
@@ -5,7 +5,7 @@
   <parent>
 	<groupId>com.temenos.interaction</groupId>
 	<artifactId>interaction-parent</artifactId>
-	<version>0.6.1</version>
+	<version>0.6.2-SNAPSHOT</version>
 	<relativePath>../../interaction-parent/pom.xml</relativePath>
   </parent>
 
@@ -180,7 +180,7 @@
     									interaction-sdk-plugin
     								</artifactId>
     								<versionRange>
-    									[0.6.1,)
+    									[0.6.2-SNAPSHOT,)
     								</versionRange>
     								<goals>
     									<goal>rim-generate</goal>
@@ -199,7 +199,7 @@
     									interaction-sdk-rim-plugin
     								</artifactId>
     								<versionRange>
-    									[0.6.1,)
+    									[0.6.2-SNAPSHOT,)
     								</versionRange>
     								<goals>
     									<goal>rim-generate</goal>

--- a/interaction-examples/interaction-mashup-streaming/pom.xml
+++ b/interaction-examples/interaction-mashup-streaming/pom.xml
@@ -5,7 +5,7 @@
   <parent>
 	<groupId>com.temenos.interaction</groupId>
 	<artifactId>interaction-parent</artifactId>
-	<version>0.6.1</version>
+	<version>0.6.2-SNAPSHOT</version>
 	<relativePath>../../interaction-parent/pom.xml</relativePath>
   </parent>
 
@@ -162,7 +162,7 @@
     									interaction-sdk-plugin
     								</artifactId>
     								<versionRange>
-    									[0.6.1,)
+    									[0.6.2-SNAPSHOT,)
     								</versionRange>
     								<goals>
     									<goal>rim-generate</goal>
@@ -181,7 +181,7 @@
     									interaction-sdk-rim-plugin
     								</artifactId>
     								<versionRange>
-    									[0.6.1,)
+    									[0.6.2-SNAPSHOT,)
     								</versionRange>
     								<goals>
     									<goal>rim-generate</goal>

--- a/interaction-examples/interaction-mashup-twitter/pom.xml
+++ b/interaction-examples/interaction-mashup-twitter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
 	<groupId>com.temenos.interaction</groupId>
 	<artifactId>interaction-parent</artifactId>
-	<version>0.6.1</version>
+	<version>0.6.2-SNAPSHOT</version>
 	<relativePath>../../interaction-parent/pom.xml</relativePath>
   </parent>
 

--- a/interaction-examples/interaction-odata-airline/pom.xml
+++ b/interaction-examples/interaction-odata-airline/pom.xml
@@ -5,7 +5,7 @@
   <parent>
 	<groupId>com.temenos.interaction</groupId>
 	<artifactId>interaction-parent</artifactId>
-	<version>0.6.1</version>
+	<version>0.6.2-SNAPSHOT</version>
 	<relativePath>../../interaction-parent/pom.xml</relativePath>
   </parent>
 
@@ -181,7 +181,7 @@
     									interaction-sdk-rim-plugin
     								</artifactId>
     								<versionRange>
-    									[0.6.1,)
+    									[0.6.2-SNAPSHOT,)
     								</versionRange>
     								<goals>
     									<goal>rim-generate</goal>

--- a/interaction-examples/interaction-odata-embedded/pom.xml
+++ b/interaction-examples/interaction-odata-embedded/pom.xml
@@ -25,7 +25,7 @@
   <parent>
 	<groupId>com.temenos.interaction</groupId>
 	<artifactId>interaction-parent</artifactId>
-	<version>0.6.1</version>
+	<version>0.6.2-SNAPSHOT</version>
 	<relativePath>../../interaction-parent/pom.xml</relativePath>
   </parent>
 
@@ -65,7 +65,7 @@
       <plugin>
         <groupId>com.temenos.interaction</groupId>
         <artifactId>interaction-sdk-plugin</artifactId>
-        <version>0.6.1</version>
+        <version>0.6.2-SNAPSHOT</version>
         <configuration>
           <edmxFile>${basedir}/service.edmx</edmxFile>
           <srcTargetDirectory>${basedir}/src/main/java</srcTargetDirectory>
@@ -76,7 +76,7 @@
       <plugin>
         <groupId>com.temenos.interaction</groupId>
         <artifactId>interaction-sdk-rim-plugin</artifactId>
-        <version>0.6.1</version>
+        <version>0.6.2-SNAPSHOT</version>
         <executions>
           <!-- Generate the Java source from the RIM during each build -->
           <execution>
@@ -203,7 +203,7 @@
     									interaction-sdk-rim-plugin
     								</artifactId>
     								<versionRange>
-    									[0.6.1,)
+    									[0.6.2-SNAPSHOT,)
     								</versionRange>
     								<goals>
     									<goal>rim-generate</goal>

--- a/interaction-examples/interaction-odata-error/pom.xml
+++ b/interaction-examples/interaction-odata-error/pom.xml
@@ -25,7 +25,7 @@
   <parent>
 	<groupId>com.temenos.interaction</groupId>
 	<artifactId>interaction-parent</artifactId>
-	<version>0.6.1</version>
+	<version>0.6.2-SNAPSHOT</version>
 	<relativePath>../../interaction-parent/pom.xml</relativePath>
   </parent>
 
@@ -65,7 +65,7 @@
       <plugin>
         <groupId>com.temenos.interaction</groupId>
         <artifactId>interaction-sdk-plugin</artifactId>
-        <version>0.6.1</version>
+        <version>0.6.2-SNAPSHOT</version>
         <configuration>
           <edmxFile>${basedir}/service.edmx</edmxFile>
           <srcTargetDirectory>${basedir}/src/main/java</srcTargetDirectory>
@@ -76,7 +76,7 @@
       <plugin>
         <groupId>com.temenos.interaction</groupId>
         <artifactId>interaction-sdk-rim-plugin</artifactId>
-        <version>0.6.1</version>
+        <version>0.6.2-SNAPSHOT</version>
         <executions>
           <!-- Generate the Java source from the RIM during each build -->
           <execution>
@@ -203,7 +203,7 @@
     									interaction-sdk-rim-plugin
     								</artifactId>
     								<versionRange>
-    									[0.6.1,)
+    									[0.6.2-SNAPSHOT,)
     								</versionRange>
     								<goals>
     									<goal>rim-generate</goal>

--- a/interaction-examples/interaction-odata-etag/pom.xml
+++ b/interaction-examples/interaction-odata-etag/pom.xml
@@ -25,7 +25,7 @@
   <parent>
 	<groupId>com.temenos.interaction</groupId>
 	<artifactId>interaction-parent</artifactId>
-	<version>0.6.1</version>
+	<version>0.6.2-SNAPSHOT</version>
 	<relativePath>../../interaction-parent/pom.xml</relativePath>
   </parent>
 
@@ -65,7 +65,7 @@
       <plugin>
         <groupId>com.temenos.interaction</groupId>
         <artifactId>interaction-sdk-plugin</artifactId>
-        <version>0.6.1</version>
+        <version>0.6.2-SNAPSHOT</version>
         <configuration>
           <edmxFile>${basedir}/service.edmx</edmxFile>
           <srcTargetDirectory>${basedir}/src/main/java</srcTargetDirectory>
@@ -203,7 +203,7 @@
     									interaction-sdk-plugin
     								</artifactId>
     								<versionRange>
-    									[0.6.1,)
+    									[0.6.2-SNAPSHOT,)
     								</versionRange>
     								<goals>
     									<goal>rim-generate</goal>
@@ -222,7 +222,7 @@
     									interaction-sdk-rim-plugin
     								</artifactId>
     								<versionRange>
-    									[0.6.1,)
+    									[0.6.2-SNAPSHOT,)
     								</versionRange>
     								<goals>
     									<goal>rim-generate</goal>

--- a/interaction-examples/interaction-odata-multicompany/pom.xml
+++ b/interaction-examples/interaction-odata-multicompany/pom.xml
@@ -5,7 +5,7 @@
   <parent>
 	<groupId>com.temenos.interaction</groupId>
 	<artifactId>interaction-parent</artifactId>
-	<version>0.6.1</version>
+	<version>0.6.2-SNAPSHOT</version>
 	<relativePath>../../interaction-parent/pom.xml</relativePath>
   </parent>
 
@@ -180,7 +180,7 @@
     									interaction-sdk-rim-plugin
     								</artifactId>
     								<versionRange>
-    									[0.6.1,)
+    									[0.6.2-SNAPSHOT,)
     								</versionRange>
     								<goals>
     									<goal>rim-generate</goal>

--- a/interaction-examples/interaction-odata-northwind/pom.xml
+++ b/interaction-examples/interaction-odata-northwind/pom.xml
@@ -5,7 +5,7 @@
   <parent>
 	<groupId>com.temenos.interaction</groupId>
 	<artifactId>interaction-parent</artifactId>
-	<version>0.6.1</version>
+	<version>0.6.2-SNAPSHOT</version>
 	<relativePath>../../interaction-parent/pom.xml</relativePath>
   </parent>
 
@@ -28,7 +28,7 @@
       <plugin>
         <groupId>com.temenos.interaction</groupId>
         <artifactId>interaction-sdk-plugin</artifactId>
-        <version>0.6.1</version>
+        <version>0.6.2-SNAPSHOT</version>
         <configuration>
           <edmxFile>${basedir}/src/main/resources/edmx.xml</edmxFile>
           <srcTargetDirectory>${basedir}/src/main/java</srcTargetDirectory>

--- a/interaction-examples/interaction-odata-notes/pom.xml
+++ b/interaction-examples/interaction-odata-notes/pom.xml
@@ -5,7 +5,7 @@
   <parent>
 	<groupId>com.temenos.interaction</groupId>
 	<artifactId>interaction-parent</artifactId>
-	<version>0.6.1</version>
+	<version>0.6.2-SNAPSHOT</version>
 	<relativePath>../../interaction-parent/pom.xml</relativePath>
   </parent>
 
@@ -41,7 +41,7 @@
       <plugin>
         <groupId>com.temenos.interaction</groupId>
         <artifactId>interaction-sdk-plugin</artifactId>
-        <version>0.6.1</version>
+        <version>0.6.2-SNAPSHOT</version>
 <!--		
 		<executions>
           <execution>

--- a/interaction-media-hal/pom.xml
+++ b/interaction-media-hal/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.temenos.interaction</groupId>
 		<artifactId>interaction-parent</artifactId>
-		<version>0.6.1</version>
+		<version>0.6.2-SNAPSHOT</version>
 		<relativePath>../interaction-parent/pom.xml</relativePath>
 	</parent>
 

--- a/interaction-media-odata-xml/pom.xml
+++ b/interaction-media-odata-xml/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.temenos.interaction</groupId>
 		<artifactId>interaction-parent</artifactId>
-		<version>0.6.1</version>
+		<version>0.6.2-SNAPSHOT</version>
 		<relativePath>../interaction-parent/pom.xml</relativePath>
 	</parent>
 

--- a/interaction-media-xhtml/pom.xml
+++ b/interaction-media-xhtml/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.temenos.interaction</groupId>
 		<artifactId>interaction-parent</artifactId>
-		<version>0.6.1</version>
+		<version>0.6.2-SNAPSHOT</version>
 		<relativePath>../interaction-parent/pom.xml</relativePath>
 	</parent>
 

--- a/interaction-odata4j-ext/pom.xml
+++ b/interaction-odata4j-ext/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.temenos.interaction</groupId>
 		<artifactId>interaction-parent</artifactId>
-		<version>0.6.1</version>
+		<version>0.6.2-SNAPSHOT</version>
 		<relativePath>../interaction-parent/pom.xml</relativePath>
 	</parent>
 

--- a/interaction-parent/pom.xml
+++ b/interaction-parent/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.temenos.interaction</groupId>
 	<artifactId>interaction-parent</artifactId>
-	<version>0.6.1</version>
+	<version>0.6.2-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>interaction-parent</name>
 

--- a/interaction-sdk-archetype/pom.xml
+++ b/interaction-sdk-archetype/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.temenos.interaction</groupId>
 		<artifactId>interaction-parent</artifactId>
-		<version>0.6.1</version>
+		<version>0.6.2-SNAPSHOT</version>
 		<relativePath>../interaction-parent/pom.xml</relativePath>
 	</parent>
 

--- a/interaction-sdk-plugin/pom.xml
+++ b/interaction-sdk-plugin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.temenos.interaction</groupId>
 		<artifactId>interaction-parent</artifactId>
-		<version>0.6.1</version>
+		<version>0.6.2-SNAPSHOT</version>
 		<relativePath>../interaction-parent/pom.xml</relativePath>
 	</parent>
 

--- a/interaction-sdk-rim-plugin/pom.xml
+++ b/interaction-sdk-rim-plugin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.temenos.interaction</groupId>
 		<artifactId>interaction-parent</artifactId>
-		<version>0.6.1</version>
+		<version>0.6.2-SNAPSHOT</version>
 		<relativePath>../interaction-parent/pom.xml</relativePath>
 	</parent>
 

--- a/interaction-sdk-test/pom.xml
+++ b/interaction-sdk-test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.temenos.interaction</groupId>
 		<artifactId>interaction-parent</artifactId>
-		<version>0.6.1</version>
+		<version>0.6.2-SNAPSHOT</version>
 		<relativePath>../interaction-parent/pom.xml</relativePath>
 	</parent>
 
@@ -13,7 +13,7 @@
 	<name>interaction-sdk-test</name>
 
 	<properties>
-		<archetypeVersion>0.6.1</archetypeVersion>
+		<archetypeVersion>0.6.2-SNAPSHOT</archetypeVersion>
 		<flightResponderVersion>1.0-SNAPSHOT</flightResponderVersion>
 		<insertFile>${basedir}/src/test/resources/responder_insert.sql</insertFile>
 	</properties>

--- a/interaction-sdk/pom.xml
+++ b/interaction-sdk/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.temenos.interaction</groupId>
 		<artifactId>interaction-parent</artifactId>
-		<version>0.6.1</version>
+		<version>0.6.2-SNAPSHOT</version>
 		<relativePath>../interaction-parent/pom.xml</relativePath>
 	</parent>
 

--- a/interaction-test/pom.xml
+++ b/interaction-test/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>interaction-parent</artifactId>
     <groupId>com.temenos.interaction</groupId>
-    <version>0.6.1</version>
+    <version>0.6.2-SNAPSHOT</version>
     <relativePath>../interaction-parent/pom.xml</relativePath>
   </parent>
 

--- a/interaction-winkext/pom.xml
+++ b/interaction-winkext/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.temenos.interaction</groupId>
 		<artifactId>interaction-parent</artifactId>
-		<version>0.6.1</version>
+		<version>0.6.2-SNAPSHOT</version>
 		<relativePath>../interaction-parent/pom.xml</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.temenos.interaction</groupId>
     <artifactId>interaction</artifactId>
-    <version>0.6.1</version>
+    <version>0.6.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>IRIS</name>

--- a/useragent-examples/pom.xml
+++ b/useragent-examples/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.temenos.interaction</groupId>
 	<artifactId>useragent-examples</artifactId>
-	<version>0.6.1</version>
+	<version>0.6.2-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/useragent-examples/useragent-examples-simple/pom.xml
+++ b/useragent-examples/useragent-examples-simple/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.temenos.interaction</groupId>
 		<artifactId>interaction-parent</artifactId>
-		<version>0.6.1</version>
+		<version>0.6.2-SNAPSHOT</version>
 		<relativePath>../../interaction-parent/pom.xml</relativePath>
 	</parent>
 

--- a/useragent-examples/useragent-generic-javascript/pom.xml
+++ b/useragent-examples/useragent-generic-javascript/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.temenos.interaction</groupId>
     <artifactId>interaction-parent</artifactId>
-    <version>0.6.1</version>
+    <version>0.6.2-SNAPSHOT</version>
     <relativePath>../../interaction-parent/pom.xml</relativePath>
   </parent>
 

--- a/useragent-examples/useragent-hal-inspector/pom.xml
+++ b/useragent-examples/useragent-hal-inspector/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.temenos.interaction</groupId>
     <artifactId>interaction-parent</artifactId>
-    <version>0.6.1</version>
+    <version>0.6.2-SNAPSHOT</version>
     <relativePath>../../interaction-parent/pom.xml</relativePath>
   </parent>
 

--- a/useragent-examples/useragent-javascript-tester/pom.xml
+++ b/useragent-examples/useragent-javascript-tester/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.temenos.interaction</groupId>
     <artifactId>interaction-parent</artifactId>
-    <version>0.6.1</version>
+    <version>0.6.2-SNAPSHOT</version>
     <relativePath>../../interaction-parent/pom.xml</relativePath>
   </parent>
 

--- a/useragent-examples/useragent-odata-html5/pom.xml
+++ b/useragent-examples/useragent-odata-html5/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.temenos.interaction</groupId>
     <artifactId>interaction-parent</artifactId>
-    <version>0.6.1</version>
+    <version>0.6.2-SNAPSHOT</version>
     <relativePath>../../interaction-parent/pom.xml</relativePath>
   </parent>
 

--- a/useragent-examples/useragent-swagger-ui/pom.xml
+++ b/useragent-examples/useragent-swagger-ui/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.temenos.interaction</groupId>
     <artifactId>interaction-parent</artifactId>
-    <version>0.6.1</version>
+    <version>0.6.2-SNAPSHOT</version>
     <relativePath>../../interaction-parent/pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
The packaging of the models into a jar puts the properties files used by the SpringDSL implementation into the root, where they are loaded via a spring wildcard pattern.
That works in JBoss but not in Weblogic (because of differences in the Classloader implementations)
To be more robust, this change generates the properties files into the META-INF directory.
The SpringDSL implementation will now look both in the root and the META-INF, to remain compatible with models jars already produced the old way.

0.6.1 is published, so this will become 0.6.2
