### PR TITLE
Move properties files down into META-INF

### DIFF
--- a/interaction-dsl/com.temenos.interaction.rimdsl.tests/src/com/temenos/interaction/rimdsl/GeneratorSpringPRDTest.java
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.tests/src/com/temenos/interaction/rimdsl/GeneratorSpringPRDTest.java
@@ -129,7 +129,7 @@ public class GeneratorSpringPRDTest {
 		Map<String, Object> allFiles = fsa.getAllFiles();
 		assertEquals(2, fsa.getAllFiles().size());
 		assertTrue(allFiles.containsKey(IFileSystemAccess.DEFAULT_OUTPUT + "IRIS-Test-PRD.xml"));
-		assertTrue(allFiles.containsKey(IFileSystemAccess.DEFAULT_OUTPUT + "IRIS-Test.properties"));
+		assertTrue(allFiles.containsKey(IFileSystemAccess.DEFAULT_OUTPUT + "META-INF/IRIS-Test.properties"));
 	}
 
 	/**
@@ -146,7 +146,7 @@ public class GeneratorSpringPRDTest {
 		underTest.doGenerate(model.eResource(), fsa);
 
 		Map<String, Object> allFiles = fsa.getAllFiles();
-		String output = allFiles.get(IFileSystemAccess.DEFAULT_OUTPUT + "IRIS-Test.properties").toString();
+		String output = allFiles.get(IFileSystemAccess.DEFAULT_OUTPUT + "META-INF/IRIS-Test.properties").toString();
 		assertTrue(output.contains("Test-A=GET /A"));
 	}
 
@@ -174,7 +174,7 @@ public class GeneratorSpringPRDTest {
 		underTest.doGenerate(model.eResource(), fsa);
 
 		Map<String, Object> allFiles = fsa.getAllFiles();
-		String output = allFiles.get(IFileSystemAccess.DEFAULT_OUTPUT + "IRIS-Test.properties").toString();
+		String output = allFiles.get(IFileSystemAccess.DEFAULT_OUTPUT + "META-INF/IRIS-Test.properties").toString();
 		assertTrue(output.contains("Test-A=GET,POST /A"));
 	}
 

--- a/interaction-dsl/com.temenos.interaction.rimdsl/src/com/temenos/interaction/rimdsl/generator/RIMDslGeneratorSpringPRD.xtend
+++ b/interaction-dsl/com.temenos.interaction.rimdsl/src/com/temenos/interaction/rimdsl/generator/RIMDslGeneratorSpringPRD.xtend
@@ -48,7 +48,7 @@ class RIMDslGeneratorSpringPRD implements IGenerator {
         
         fsa.generateFile("IRIS-" + rimName + "-PRD.xml", toSpringXML(rim))
 
-        fsa.generateFile("IRIS-" + rimName + ".properties", toBeanMap(rim))
+        fsa.generateFile("META-INF/IRIS-" + rimName + ".properties", toBeanMap(rim))
 	}
 
 	

--- a/interaction-dsl/interaction-springdsl/src/main/resources/IRIS-SpringDSL-main.xml
+++ b/interaction-dsl/interaction-springdsl/src/main/resources/IRIS-SpringDSL-main.xml
@@ -38,6 +38,7 @@
   		<property name="locations">
     		<list>
       			<value>classpath*:IRIS-*.properties</value>
+      			<value>classpath*:/META-INF/IRIS-*.properties</value>
     		</list>
   		</property>
 	</bean>


### PR DESCRIPTION
to make it easier for a spring factory to find them with a wildcard pattern.