### PR TITLE
Fixed error during unloading metadata caused by unhandled RecordNotFound...

### DIFF
--- a/interaction-odata4j-ext/src/main/java/com/temenos/interaction/odataext/entity/MetadataOData4j.java
+++ b/interaction-odata4j-ext/src/main/java/com/temenos/interaction/odataext/entity/MetadataOData4j.java
@@ -285,7 +285,7 @@ public class MetadataOData4j {
 				if (edmDataServices != null) {
 					// EDM data services has already been initialized
 
-					if (edmDataServices.getEdmEntitySet(entitySetName) != null) {
+					if (edmDataServices.findEdmEntitySet(entitySetName) != null) {
 						// EDM data services, i.e. service document, contains entity set therefore it needs to be rebuilt
 						edmDataServices = null;
 					}


### PR DESCRIPTION
...Exception; the solution replaces the existing method call with an equivalent method call that returns null instead of throwing an exception when an entity set is not found.