### PR TITLE
Adding support for loading IRIS configuration files from the file system

### DIFF
--- a/interaction-core/src/main/java/com/temenos/interaction/core/resource/ConfigLoader.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/resource/ConfigLoader.java
@@ -40,7 +40,7 @@ public class ConfigLoader {
 	
 	private final static Logger logger = LoggerFactory.getLogger(ConfigLoader.class);	
 	
-	InputStream load(String filename) throws FileNotFoundException, Exception {
+	public InputStream load(String filename) throws FileNotFoundException, Exception {
 		InputStream is = null;
 		
 		if(System.getProperty(IRIS_CONFIG_DIR_PROP) == null) {

--- a/interaction-core/src/main/java/com/temenos/interaction/core/resource/ConfigLoader.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/resource/ConfigLoader.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ConfigLoader {
 	// System property defining the location of the unpacked IRIS configuration files
-	private static final String IRIS_CONFIG_DIR_PROP = "com.temenos.interaction.config.dir";
+	public static final String IRIS_CONFIG_DIR_PROP = "com.temenos.interaction.config.dir";
 	
 	private final static Logger logger = LoggerFactory.getLogger(ConfigLoader.class);	
 	
@@ -48,6 +48,8 @@ public class ConfigLoader {
 			
 			if(is == null) {
 				logger.error("Unable to load " + filename + " from classpath.");
+				
+				throw new Exception("Unable to load " + filename + " from classpath.");
 			}
 		} else {
 			String irisResourceDirPath = System.getProperty(IRIS_CONFIG_DIR_PROP);
@@ -59,7 +61,8 @@ public class ConfigLoader {
 				if(file.exists()) {
 					is = new FileInputStream(file);
 				} else {
-					logger.error("Unable to load " + filename + " from file system.");
+					logger.error("Unable to load " + filename + " from directory " + irisResourceDir + " (specified by " 
+							+ IRIS_CONFIG_DIR_PROP + "system property)");
 					throw new Exception("Unable to load " + filename + " from file system.");
 				}
 			} else {

--- a/interaction-core/src/main/java/com/temenos/interaction/core/resource/ConfigLoader.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/resource/ConfigLoader.java
@@ -1,0 +1,72 @@
+package com.temenos.interaction.core.resource;
+
+/*
+ * #%L
+ * interaction-core
+ * %%
+ * Copyright (C) 2012 - 2015 Temenos Holdings N.V.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class provides an abstraction from the underlying mechanism used to load config files  
+ *
+ */
+public class ConfigLoader {
+	// System property defining the location of the unpacked IRIS configuration files
+	private static final String IRIS_CONFIG_DIR_PROP = "com.temenos.interaction.config.dir";
+	
+	private final static Logger logger = LoggerFactory.getLogger(ConfigLoader.class);	
+	
+	InputStream load(String filename) throws FileNotFoundException, Exception {
+		InputStream is = null;
+		
+		if(System.getProperty(IRIS_CONFIG_DIR_PROP) == null) {
+			is = getClass().getClassLoader().getResourceAsStream(filename);
+			
+			if(is == null) {
+				logger.error("Unable to load " + filename + " from classpath.");
+			}
+		} else {
+			String irisResourceDirPath = System.getProperty(IRIS_CONFIG_DIR_PROP);
+			File irisResourceDir = new File(irisResourceDirPath);
+			
+			if(irisResourceDir.exists() && irisResourceDir.isDirectory()) {
+				File file = new File(irisResourceDir, filename);			
+				
+				if(file.exists()) {
+					is = new FileInputStream(file);
+				} else {
+					logger.error("Unable to load " + filename + " from file system.");
+					throw new Exception("Unable to load " + filename + " from file system.");
+				}
+			} else {
+				throw new Exception("The IRIS resource config directory specified (" + IRIS_CONFIG_DIR_PROP + ") does not exist.");
+			}
+		}
+		
+		return is;
+	}
+}

--- a/interaction-core/src/main/java/com/temenos/interaction/core/resource/ResourceMetadataManager.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/resource/ResourceMetadataManager.java
@@ -186,8 +186,12 @@ public class ResourceMetadataManager {
 			InputStream is = loader.load(metadataFilename);
 			
 			if(is == null) {
-				metadataFilename = METADATA_XML_FILE;
-				is = loader.load(metadataFilename);
+				is = loader.load(METADATA_XML_FILE);
+				
+				if(is == null) {
+					logger.error("Unable to load " + METADATA_XML_FILE + " from classpath.");
+					throw new Exception("Unable to load " + metadataFilename + " and " + METADATA_XML_FILE + " from classpath.");
+				}				
 			}
 			
 			return new MetadataParser(termFactory).parse(is);

--- a/interaction-core/src/main/java/com/temenos/interaction/core/resource/ResourceMetadataManager.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/resource/ResourceMetadataManager.java
@@ -182,18 +182,16 @@ public class ResourceMetadataManager {
 			metadataFilename = "metadata-" + entityName + ".xml";
 		}
 		
-		try {			
-			InputStream is = loader.load(metadataFilename);
+		try {
+			InputStream is = null;
 			
-			if(is == null) {
+			try {
+				is = loader.load(metadataFilename);
+			} catch(Exception e ) {
+				// Try to load default metadata file
 				is = loader.load(METADATA_XML_FILE);
-				
-				if(is == null) {
-					logger.error("Unable to load " + METADATA_XML_FILE + " from classpath.");
-					throw new Exception("Unable to load " + metadataFilename + " and " + METADATA_XML_FILE + " from classpath.");
-				}				
 			}
-			
+						
 			return new MetadataParser(termFactory).parse(is);
 		}
 		catch(Exception e) {

--- a/interaction-core/src/main/java/com/temenos/interaction/core/resource/ResourceMetadataManager.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/resource/ResourceMetadataManager.java
@@ -40,11 +40,12 @@ import com.temenos.interaction.core.hypermedia.ResourceStateMachine;
 public class ResourceMetadataManager {
 	
 	private final static Logger logger = LoggerFactory.getLogger(ResourceMetadataManager.class);
-
+	
 	private final static String METADATA_XML_FILE = "metadata.xml";
 
 	private Metadata metadata = null;
 	private TermFactory termFactory = null;
+	private ConfigLoader loader = new ConfigLoader();
 	
 	/**
 	 * Construct the metadata object
@@ -181,16 +182,14 @@ public class ResourceMetadataManager {
 			metadataFilename = "metadata-" + entityName + ".xml";
 		}
 		
-		try {
-			InputStream is = getClass().getClassLoader().getResourceAsStream(metadataFilename);
+		try {			
+			InputStream is = loader.load(metadataFilename);
+			
 			if(is == null) {
-				logger.error("Unable to load " + metadataFilename + " from classpath.");
-				is = getClass().getClassLoader().getResourceAsStream(METADATA_XML_FILE);
-				if(is == null) {
-					logger.error("Unable to load " + METADATA_XML_FILE + " from classpath.");
-					throw new Exception("Unable to load " + metadataFilename + " and " + METADATA_XML_FILE + " from classpath.");
-				}
+				metadataFilename = METADATA_XML_FILE;
+				is = loader.load(metadataFilename);
 			}
+			
 			return new MetadataParser(termFactory).parse(is);
 		}
 		catch(Exception e) {

--- a/interaction-dsl/interaction-springdsl/src/main/java/com/temenos/interaction/springdsl/SpringDSLPropertiesFactoryBean.java
+++ b/interaction-dsl/interaction-springdsl/src/main/java/com/temenos/interaction/springdsl/SpringDSLPropertiesFactoryBean.java
@@ -32,13 +32,13 @@ import org.springframework.beans.factory.config.PropertiesFactoryBean;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 
+import com.temenos.interaction.core.resource.ConfigLoader;
+
 /**
  * This class enhances the Spring PropertiesFactoryBean class to provide support for loading IRIS configuration files 
  * from a directory defined as a system property.
  */
 public class SpringDSLPropertiesFactoryBean extends PropertiesFactoryBean {
-	// System property defining the location of the unpacked IRIS configuration files
-	private static final String IRIS_CONFIG_DIR_PROP = "com.temenos.interaction.config.dir";
 	
 	private String filenamePattern;
 	
@@ -55,9 +55,9 @@ public class SpringDSLPropertiesFactoryBean extends PropertiesFactoryBean {
 		List<Resource> tmpLocations = new ArrayList<Resource>();
 		tmpLocations.addAll(Arrays.asList(locations));
 		
-		if(System.getProperty(IRIS_CONFIG_DIR_PROP) != null) {
+		if(System.getProperty(ConfigLoader.IRIS_CONFIG_DIR_PROP) != null) {
 			// Try and load the properties from the file system as a resource directory has been specified
-			String irisResourceDirPath = System.getProperty(IRIS_CONFIG_DIR_PROP);
+			String irisResourceDirPath = System.getProperty(ConfigLoader.IRIS_CONFIG_DIR_PROP);
 			File irisResourceDir = new File(irisResourceDirPath);
 			
 			if(irisResourceDir.exists() && irisResourceDir.isDirectory()) {

--- a/interaction-dsl/interaction-springdsl/src/main/java/com/temenos/interaction/springdsl/SpringDSLPropertiesFactoryBean.java
+++ b/interaction-dsl/interaction-springdsl/src/main/java/com/temenos/interaction/springdsl/SpringDSLPropertiesFactoryBean.java
@@ -1,0 +1,80 @@
+package com.temenos.interaction.springdsl;
+
+/*
+ * #%L
+ * interaction-springdsl
+ * %%
+ * Copyright (C) 2012 - 2015 Temenos Holdings N.V.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.beans.factory.config.PropertiesFactoryBean;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+
+/**
+ * This class enhances the Spring PropertiesFactoryBean class to provide support for loading IRIS configuration files 
+ * from a directory defined as a system property.
+ */
+public class SpringDSLPropertiesFactoryBean extends PropertiesFactoryBean {
+	// System property defining the location of the unpacked IRIS configuration files
+	private static final String IRIS_CONFIG_DIR_PROP = "com.temenos.interaction.config.dir";
+	
+	private String filenamePattern;
+	
+	/**
+	 * @param filenamePattern The file name pattern to use if properties files are being loaded from the file system
+	 */
+	public SpringDSLPropertiesFactoryBean(String filenamePattern) {
+		this.filenamePattern = filenamePattern;
+	}
+
+
+	@Override
+	public void setLocations(Resource[] locations) {
+		List<Resource> tmpLocations = new ArrayList<Resource>();
+		tmpLocations.addAll(Arrays.asList(locations));
+		
+		if(System.getProperty(IRIS_CONFIG_DIR_PROP) != null) {
+			// Try and load the properties from the file system as a resource directory has been specified
+			String irisResourceDirPath = System.getProperty(IRIS_CONFIG_DIR_PROP);
+			File irisResourceDir = new File(irisResourceDirPath);
+			
+			if(irisResourceDir.exists() && irisResourceDir.isDirectory()) {
+				File[] files = irisResourceDir.listFiles(new FilenameFilter() {
+					@Override
+					public boolean accept(File dir, String name) {
+						return name.matches(filenamePattern);
+					}
+				});
+				
+				for(File file: files) {
+					// Create a resource for a current file and add it to the collection of properties resources
+					tmpLocations.add(new FileSystemResource(file));
+				}
+			}		
+		}
+		
+		super.setLocations(tmpLocations.toArray(new Resource[0]));		
+	}
+}

--- a/interaction-dsl/interaction-springdsl/src/main/java/com/temenos/interaction/springdsl/SpringDSLResourceStateProvider.java
+++ b/interaction-dsl/interaction-springdsl/src/main/java/com/temenos/interaction/springdsl/SpringDSLResourceStateProvider.java
@@ -42,11 +42,9 @@ import org.springframework.context.support.FileSystemXmlApplicationContext;
 import com.temenos.interaction.core.hypermedia.Event;
 import com.temenos.interaction.core.hypermedia.ResourceState;
 import com.temenos.interaction.core.hypermedia.ResourceStateProvider;
+import com.temenos.interaction.core.resource.ConfigLoader;
 
 public class SpringDSLResourceStateProvider implements ResourceStateProvider, DynamicRegistrationResourceStateProvider {
-	// System property defining the location of the unpacked IRIS configuration files
-	private static final String IRIS_CONFIG_DIR_PROP = "com.temenos.interaction.config.dir";
-
 	private final Logger logger = LoggerFactory.getLogger(SpringDSLResourceStateProvider.class);
 
 	private ConcurrentMap<String, ResourceState> resources = new ConcurrentHashMap<String, ResourceState>();
@@ -203,12 +201,12 @@ public class SpringDSLResourceStateProvider implements ResourceStateProvider, Dy
 	private ApplicationContext createApplicationContext(String beanXml) {
 		ApplicationContext result = null;
 		
-		if(System.getProperty(IRIS_CONFIG_DIR_PROP) == null) {
+		if(System.getProperty(ConfigLoader.IRIS_CONFIG_DIR_PROP) == null) {
 			// Try and load the resource from the classpath
 			result = new ClassPathXmlApplicationContext(new String[] {beanXml});
 		} else {
 			// Try and load the resource from the file system as a resource directory has been specified
-			String irisResourceDirPath = System.getProperty(IRIS_CONFIG_DIR_PROP);
+			String irisResourceDirPath = System.getProperty(ConfigLoader.IRIS_CONFIG_DIR_PROP);
 			File irisResourceDir = new File(irisResourceDirPath);
 			
 			if(irisResourceDir.exists() && irisResourceDir.isDirectory()) {

--- a/interaction-dsl/interaction-springdsl/src/main/resources/IRIS-SpringDSL-main.xml
+++ b/interaction-dsl/interaction-springdsl/src/main/resources/IRIS-SpringDSL-main.xml
@@ -32,7 +32,8 @@
 
 	<context:component-scan base-package="com.temenos.interaction.springdsl" />
 	
-	<bean id="defaultResources" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
+	<bean id="defaultResources" class="com.temenos.interaction.springdsl.SpringDSLPropertiesFactoryBean">
+		<constructor-arg name="filenamePattern" value="IRIS-.*\.properties"/>
   		<property name="singleton" value="true"/>
   		<property name="ignoreResourceNotFound" value="true"/>
   		<property name="locations">


### PR DESCRIPTION
Switched on by specifying JVM option: -Dcom.temenos.interaction.config.dir=