### PR TITLE
Upgrade to XText 2.8.3

### DIFF
--- a/interaction-dsl/com.temenos.interaction.rimdsl.generator/pom.xml
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.generator/pom.xml
@@ -104,12 +104,11 @@
                     <appendAssemblyId>false</appendAssemblyId>
                     <archive>
                         <manifest>
-                            <!-- This bug means 'addClasspath' doesn't work http://jira.codehaus.org/browse/MASSEMBLY-334 -->
+                            <!-- This bug means 'addClasspath' doesn't work http://jira.codehaus.org/browse/MASSEMBLY-334 --> 
                             <addClasspath>true</addClasspath>
                             <classpathPrefix>lib/</classpathPrefix>
                             <mainClass>com.temenos.interaction.rimdsl.generator.launcher.Launcher</mainClass>
                         </manifest>
-                        <manifestFile>${project.build.directory}/classes/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
                 <executions>
@@ -188,8 +187,19 @@
 
         <dependency>
             <groupId>org.eclipse.xtend</groupId>
-            <artifactId>org.eclipse.xtend.standalone</artifactId>
+            <artifactId>org.eclipse.xtend.lib</artifactId>
+            <version>${xtend-version}</version>
         </dependency>
+        <dependency>
+        	<groupId>org.eclipse.xtext</groupId>
+        	<artifactId>org.eclipse.xtext.common.types</artifactId>
+        	<version>${xtend-version}</version>
+        </dependency>
+		<dependency>
+   			<groupId>org.eclipse.equinox</groupId>
+   			<artifactId>common</artifactId>
+		    <version>[3.6.200-v20130402-1505,]</version>
+		</dependency>
 		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>

--- a/interaction-dsl/com.temenos.interaction.rimdsl.parent/pom.xml
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.parent/pom.xml
@@ -29,7 +29,7 @@
 		<license.licenseName>agpl_v3</license.licenseName>
 		<tycho-version>0.18.1</tycho-version>
 		<junit-version>4.8.1</junit-version>
-		<xtend-version>2.3.1</xtend-version>
+		<xtend-version>2.8.3</xtend-version>
 	</properties>
 
 	<distributionManagement>
@@ -343,7 +343,7 @@
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.xtend</groupId>
-				<artifactId>org.eclipse.xtend.standalone</artifactId>
+				<artifactId>org.eclipse.xtend.lib</artifactId>
 				<version>${xtend-version}</version>
 			</dependency>
 			<dependency>

--- a/interaction-dsl/com.temenos.interaction.rimdsl.tests/META-INF/MANIFEST.MF
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.tests/META-INF/MANIFEST.MF
@@ -8,10 +8,10 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: com.temenos.interaction.rimdsl,
  com.temenos.interaction.rimdsl.ui,
  org.eclipse.core.runtime,
- org.eclipse.xtext.junit4;bundle-version="[2.5,2.8)",
+ org.eclipse.xtext.junit4,
  org.eclipse.ui.workbench;resolution:=optional,
  org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional,
- org.eclipse.xtext.xbase.lib;bundle-version="[2.5,2.8)"
+ org.eclipse.xtext.xbase.lib
 Import-Package: com.temenos.interaction.rimdsl.visualisation.providers,
  org.apache.log4j,
  org.eclipse.jface.viewers,

--- a/interaction-dsl/com.temenos.interaction.rimdsl.ui/META-INF/MANIFEST.MF
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.ui/META-INF/MANIFEST.MF
@@ -6,15 +6,15 @@ Bundle-Version: 0.7.0.qualifier
 Bundle-SymbolicName: com.temenos.interaction.rimdsl.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: com.temenos.interaction.rimdsl;visibility:=reexport,
- org.eclipse.xtext.ui;bundle-version="[2.5,2.8)",
+ org.eclipse.xtext.ui,
  org.eclipse.ui.editors;bundle-version="3.5.0",
  org.eclipse.ui.ide;bundle-version="3.5.0",
- org.eclipse.xtext.ui.shared;bundle-version="[2.5,2.8)",
+ org.eclipse.xtext.ui.shared,
  org.eclipse.ui,
- org.eclipse.xtext.builder;bundle-version="[2.5,2.8)",
+ org.eclipse.xtext.builder,
  org.antlr.runtime,
- org.eclipse.xtext.common.types.ui;bundle-version="[2.5,2.8)",
- org.eclipse.xtext.ui.codetemplates.ui;bundle-version="[2.5,2.8)",
+ org.eclipse.xtext.common.types.ui,
+ org.eclipse.xtext.ui.codetemplates.ui,
  org.eclipse.compare
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/interaction-dsl/com.temenos.interaction.rimdsl.visualisation/META-INF/MANIFEST.MF
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.visualisation/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: com.temenos.interaction.rimdsl,
  org.eclipse.zest.layouts;bundle-version="1.1.0",
  org.eclipse.zest.core;bundle-version="1.5.0",
- org.eclipse.xtext.ui;bundle-version="[2.5,2.8)",
+ org.eclipse.xtext.ui,
  org.eclipse.ui.forms,
  org.eclipse.ui.console,
  org.eclipse.jdt.ui,

--- a/interaction-dsl/com.temenos.interaction.rimdsl/META-INF/MANIFEST.MF
+++ b/interaction-dsl/com.temenos.interaction.rimdsl/META-INF/MANIFEST.MF
@@ -5,20 +5,20 @@ Bundle-Vendor: IRIS
 Bundle-Version: 0.7.0.qualifier
 Bundle-SymbolicName: com.temenos.interaction.rimdsl; singleton:=true
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.xtext;bundle-version="[2.5,2.8)";visibility:=reexport,
- org.eclipse.xtext.xbase;bundle-version="[2.5,2.8)";resolution:=optional;visibility:=reexport,
- org.eclipse.xtext.generator;bundle-version="[2.5,2.8)";resolution:=optional,
+Require-Bundle: org.eclipse.xtext;bundle-version="[2.8.3,2.9)";visibility:=reexport,
+ org.eclipse.xtext.xbase;bundle-version="[2.8.3,2.9)";resolution:=optional;visibility:=reexport,
+ org.eclipse.xtext.generator;bundle-version="[2.8.3,2.9)";resolution:=optional,
  org.apache.commons.logging;bundle-version="1.0.4";resolution:=optional,
  org.eclipse.emf.codegen.ecore;resolution:=optional,
  org.eclipse.emf.mwe.utils;resolution:=optional,
  org.eclipse.emf.mwe2.launch;resolution:=optional,
- org.eclipse.xtext.util;bundle-version="[2.5,2.8)",
+ org.eclipse.xtext.util;bundle-version="[2.8.3,2.9)",
  org.eclipse.emf.ecore,
  org.eclipse.emf.common,
  org.antlr.runtime,
- org.eclipse.xtext.common.types;bundle-version="[2.5,2.8)",
+ org.eclipse.xtext.common.types;bundle-version="[2.8.3,2.9)",
  org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional,
- org.eclipse.xtext.xbase.lib;bundle-version="[2.5,2.8)"
+ org.eclipse.xtext.xbase.lib;bundle-version="[2.8.3,2.9)"
 Import-Package: org.apache.log4j,
  org.eclipse.xtext.xbase.lib
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/interaction-dsl/com.temenos.interaction.rimdsl/pom.xml
+++ b/interaction-dsl/com.temenos.interaction.rimdsl/pom.xml
@@ -80,7 +80,7 @@
 											xtend-maven-plugin
 										</artifactId>
 										<versionRange>
-											[2.3.0,)
+											[2.8.3,2.9)
 										</versionRange>
 										<goals>
 											<goal>compile</goal>

--- a/interaction-parent/pom.xml
+++ b/interaction-parent/pom.xml
@@ -129,6 +129,7 @@
 		<slf4j.version>1.6.2</slf4j.version>
 		<spring.version>3.1.4.RELEASE</spring.version>
 		<joda.version>1.6</joda.version>
+		<xtext.version>2.8.3</xtext.version>
 	</properties>
 
 	<build>

--- a/interaction-sdk-plugin/pom.xml
+++ b/interaction-sdk-plugin/pom.xml
@@ -93,17 +93,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.xtend</groupId>
-            <artifactId>org.eclipse.xtend.standalone</artifactId>
-            <version>2.3.1</version>
+            <artifactId>org.eclipse.xtend.lib</artifactId>
+            <version>${xtext.version}</version>
         </dependency>
 
 	</dependencies>
-
-	<repositories>
-		<repository>
-			<id>xtend</id>
-			<url>http://build.eclipse.org/common/xtend/maven/</url>
-		</repository>
-	</repositories>
 
 </project>

--- a/interaction-sdk-rim-plugin/pom.xml
+++ b/interaction-sdk-rim-plugin/pom.xml
@@ -93,8 +93,8 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.xtend</groupId>
-            <artifactId>org.eclipse.xtend.standalone</artifactId>
-            <version>2.3.1</version>
+            <artifactId>org.eclipse.xtend.lib</artifactId>
+			<version>${xtext.version}</version>
         </dependency>
 
 	</dependencies>


### PR DESCRIPTION
Note xtext and xtend are in sync: xtend depends on xtext.
We used to use a 'xtend-standalone' jar, which has been discontinued from 2.5
So there is now an additional dependency on org.eclipse.equinox.common