### PR TITLE
Explicitly add xbase as a dependency

### DIFF
--- a/interaction-dsl/com.temenos.interaction.rimdsl.generator/pom.xml
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.generator/pom.xml
@@ -195,6 +195,11 @@
         	<artifactId>org.eclipse.xtext.common.types</artifactId>
         	<version>${xtend-version}</version>
         </dependency>
+        <dependency>
+        	<groupId>org.eclipse.xtext</groupId>
+        	<artifactId>org.eclipse.xtext.xbase.lib</artifactId>
+        	<version>${xtend-version}</version>
+        </dependency>
 		<dependency>
    			<groupId>org.eclipse.equinox</groupId>
    			<artifactId>common</artifactId>


### PR DESCRIPTION
This dependency was previously pulled in by the xtend-standalone. It is still implicitly a dependency, but somehow the build is getting confused as to where to pull it from, leading to intermittent failures on the CI server.