### PR TITLE
spring bean version updated to 3.2.13.RELEASE

### DIFF
--- a/interaction-parent/pom.xml
+++ b/interaction-parent/pom.xml
@@ -127,7 +127,7 @@
 		<powermock.version>1.4.11</powermock.version>
 		<wink.version>1.3.0</wink.version>
 		<slf4j.version>1.6.2</slf4j.version>
-		<spring.version>3.2.10.RELEASE</spring.version>
+		<spring.version>3.2.13.RELEASE</spring.version>
 		<joda.version>1.6</joda.version>
 		<xtext.version>2.8.3</xtext.version>
 

--- a/interaction-winkext/pom.xml
+++ b/interaction-winkext/pom.xml
@@ -63,11 +63,19 @@
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-context</artifactId>
                 </exclusion>
+				<exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-web</artifactId>
+                </exclusion>
             </exclusions>
 		</dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
         </dependency>
 		<dependency>
 			<groupId>com.temenos.interaction</groupId>

--- a/interaction-winkext/pom.xml
+++ b/interaction-winkext/pom.xml
@@ -58,25 +58,25 @@
 		<dependency>
 			<groupId>org.apache.wink</groupId>
 			<artifactId>wink-spring-support</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-context</artifactId>
-                </exclusion>
+			<exclusions>
 				<exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-web</artifactId>
-                </exclusion>
-            </exclusions>
+					<groupId>org.springframework</groupId>
+					<artifactId>spring-context</artifactId>
+					</exclusion>
+				<exclusion>
+					<groupId>org.springframework</groupId>
+					<artifactId>spring-web</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-web</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>com.temenos.interaction</groupId>
 			<artifactId>interaction-core</artifactId>

--- a/useragent-examples/useragent-swagger-ui/pom.xml
+++ b/useragent-examples/useragent-swagger-ui/pom.xml
@@ -15,7 +15,7 @@
   <url>http://www.temenos.com</url>
 
   <properties>
-    <lib.spring-test.version>3.2.8.RELEASE</lib.spring-test.version>
+    <lib.spring-test.version>3.2.13.RELEASE</lib.spring-test.version>
     <lib.javax.json-api.version>1.0</lib.javax.json-api.version>
     <lib.javax.json.version>1.0.4</lib.javax.json.version>
   </properties>


### PR DESCRIPTION
Reason for this change is spring-security gives the warning for existing version of spring-bean version and recommended to update the spring-bean version to 3.2.13.RELEASE
