### PR TITLE
Raise an exception if an EDM metadata property lacks a name

### DIFF
--- a/interaction-core/src/main/java/com/temenos/interaction/core/entity/MetadataParser.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/entity/MetadataParser.java
@@ -1,3 +1,4 @@
+
 package com.temenos.interaction.core.entity;
 
 /*
@@ -28,6 +29,8 @@ import java.util.Stack;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
@@ -41,6 +44,7 @@ import com.temenos.interaction.core.entity.vocabulary.terms.TermComplexType;
  * Parser to read metadata from an XML file.
  */
 public class MetadataParser extends DefaultHandler {
+	private static final Logger logger = LoggerFactory.getLogger(MetadataParser.class);
 	TermFactory termFactory;
 
 	Metadata metadata = null;
@@ -73,6 +77,7 @@ public class MetadataParser extends DefaultHandler {
 			e.printStackTrace();
 			return null;
 		}
+		logger.debug("parsed, element count = " + entityMetadata.getPropertyVocabularyKeySet().size() );
 		return metadata;
 	}
 	
@@ -121,6 +126,9 @@ public class MetadataParser extends DefaultHandler {
 				catch(Exception e) {
 					throw new SAXException(e);
 				}
+			}
+			if ( name == null ) {
+				throw new SAXException("Parse error: Property without name in Entity " + entityMetadata.getEntityName());
 			}
 			entityMetadata.setPropertyVocabulary(name, voc, propertyName.elements());
 			isComplexProperty = (propertyName.size() > 0);

--- a/interaction-core/src/main/java/com/temenos/interaction/core/resource/ResourceMetadataManager.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/resource/ResourceMetadataManager.java
@@ -198,6 +198,7 @@ public class ResourceMetadataManager {
 		} else {
 			metadataFilename = "metadata-" + entityName + ".xml";
 		}
+		logger.debug("Loading " + metadataFilename + " for " + entityName);
 		
 		InputStream is = null;
 		try {

--- a/interaction-odata4j-ext/src/main/java/com/temenos/interaction/odataext/entity/MetadataOData4j.java
+++ b/interaction-odata4j-ext/src/main/java/com/temenos/interaction/odataext/entity/MetadataOData4j.java
@@ -411,6 +411,9 @@ public class MetadataOData4j {
 			EdmEntityType.Builder bEntityType = getEdmTypeBuilder(entityMetadata, bComplexTypeMap, true);
 			if (bEntityType != null) {
 				bEntityTypeMap.put(state.getEntityName(), bEntityType);					
+			} else {
+				logger.warn("Entity name '" + state.getEntityName() + "' does not have type. " +
+							"entityMetadata=" + entityMetadata);
 			}
 		}
 					
@@ -548,6 +551,7 @@ public class MetadataOData4j {
 		
 		String complexTypePrefix = new StringBuilder(entityMetadata.getEntityName()).append("_").toString();
 		for(String propertyName : entityMetadata.getPropertyVocabularyKeySet()) {
+			logger.debug("EdmTypeBuilder["+entityMetadata.getEntityName()+"] - " + propertyName);
 			//Entity properties, lets gather some information about the property
 			String termComplex = entityMetadata.getTermValue(propertyName, TermComplexType.TERM_NAME);							// Is vocabulary a group (Complex Type)
 			boolean termList = Boolean.parseBoolean(entityMetadata.getTermValue(propertyName, TermListType.TERM_NAME));	// Is vocabulary a List of (Complex Types)


### PR DESCRIPTION
If a metadata-*.xml file has a Property element without a Name
attribute, that's an error. It took me hours to find it didn't
work because I'd used name= instead of Name=

Also add some debug-level logging around the parsing