### PR TITLE
Support for Maven 3.3

### DIFF
--- a/interaction-sdk-plugin/pom.xml
+++ b/interaction-sdk-plugin/pom.xml
@@ -60,6 +60,12 @@
 			<artifactId>maven-plugin-api</artifactId>
 			<version>2.0</version>
 		</dependency>
+                <dependency>
+                    <groupId>org.apache.maven.plugin-tools</groupId>
+                    <artifactId>maven-plugin-annotations</artifactId>
+                    <version>3.4</version>
+                    <scope>provided</scope><!-- annotations are needed only to build the plugin -->
+                </dependency>
 		<dependency>
 			<groupId>com.temenos.interaction</groupId>
 			<artifactId>interaction-core</artifactId>

--- a/interaction-sdk-plugin/pom.xml
+++ b/interaction-sdk-plugin/pom.xml
@@ -1,79 +1,90 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>com.temenos.interaction</groupId>
-		<artifactId>interaction-parent</artifactId>
-		<version>0.8.0-SNAPSHOT</version>
-		<relativePath>../interaction-parent/pom.xml</relativePath>
-	</parent>
+    <parent>
+        <groupId>com.temenos.interaction</groupId>
+        <artifactId>interaction-parent</artifactId>
+        <version>0.8.0-SNAPSHOT</version>
+        <relativePath>../interaction-parent/pom.xml</relativePath>
+    </parent>
 
-	<artifactId>interaction-sdk-plugin</artifactId>
-	<packaging>maven-plugin</packaging>
-	<name>interaction-sdk-plugin Maven Mojo</name>
+    <artifactId>interaction-sdk-plugin</artifactId>
+    <packaging>maven-plugin</packaging>
+    <name>interaction-sdk-plugin Maven Mojo</name>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-site-plugin</artifactId>
-				<version>3.0</version>
-				<configuration>
-					<locales>en</locales>
-					<reportPlugins>
-						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-project-info-reports-plugin</artifactId>
-							<version>2.4</version>
-							<configuration>
-								<dependencyDetailsEnabled>false</dependencyDetailsEnabled>
-								<dependencyLocationsEnabled>false</dependencyLocationsEnabled>
-							</configuration>
-							<reports>
-								<report>index</report>
-								<report>dependencies</report>
-								<report>scm</report>
-							</reports>
-						</plugin>
-						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-javadoc-plugin</artifactId>
-							<version>2.8</version>
-						</plugin>
-					</reportPlugins>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.0</version>
+                <configuration>
+                    <locales>en</locales>
+                    <reportPlugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-project-info-reports-plugin</artifactId>
+                            <version>2.4</version>
+                            <configuration>
+                                <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
+                                <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
+                            </configuration>
+                            <reports>
+                                <report>index</report>
+                                <report>dependencies</report>
+                                <report>scm</report>
+                            </reports>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-javadoc-plugin</artifactId>
+                            <version>2.8</version>
+                        </plugin>
+                    </reportPlugins>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>3.4</version>
+                <executions>
+                    <execution>
+                        <id>default-descriptor</id>
+                        <phase>process-classes</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
-	<distributionManagement>
-		<site>
-			<id>interaction-sdk-plugin</id>
-			<url>file://localhost/c:/temp/iris/site/interaction-sdk-plugin</url>
-		</site>
-	</distributionManagement>
+    <distributionManagement>
+        <site>
+            <id>interaction-sdk-plugin</id>
+            <url>file://localhost/c:/temp/iris/site/interaction-sdk-plugin</url>
+        </site>
+    </distributionManagement>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-plugin-api</artifactId>
-			<version>2.0</version>
-		</dependency>
-                <dependency>
-                    <groupId>org.apache.maven.plugin-tools</groupId>
-                    <artifactId>maven-plugin-annotations</artifactId>
-                    <version>3.4</version>
-                    <scope>provided</scope><!-- annotations are needed only to build the plugin -->
-                </dependency>
-		<dependency>
-			<groupId>com.temenos.interaction</groupId>
-			<artifactId>interaction-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.temenos.interaction</groupId>
-			<artifactId>interaction-sdk</artifactId>
-		</dependency>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>3.0.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.4</version>
+            <scope>provided</scope><!-- annotations are needed only to build the plugin -->
+        </dependency>
+        <dependency>
+            <groupId>com.temenos.interaction</groupId>
+            <artifactId>interaction-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.temenos.interaction</groupId>
+            <artifactId>interaction-sdk</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.temenos.interaction</groupId>
             <artifactId>com.temenos.interaction.rimdsl</artifactId>
@@ -84,115 +95,115 @@
             <artifactId>com.temenos.interaction.rimdsl.generator</artifactId>
             <version>${project.version}</version>
         </dependency>
-		<dependency>
-			<groupId>org.powermock</groupId>
-			<artifactId>powermock-api-mockito</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.powermock</groupId>
-			<artifactId>powermock-module-junit4</artifactId>
-		</dependency>
         <dependency>
-        	<groupId>javax.inject</groupId>
-        	<artifactId>javax.inject</artifactId>
-        	<version>1</version>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.xtend</groupId>
             <artifactId>org.eclipse.xtend.lib</artifactId>
             <version>${xtext.version}</version>
         </dependency>
-	</dependencies>
+    </dependencies>
 
-	<!-- SONAR TEST COVERAGE PROFILE-->
-   <profiles>
-    <profile>
-        <id>coverage</id>
-        <build>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.13</version>
-                    <configuration>
-                        <argLine>${jacoco.agent.ut.arg}</argLine>
-                        <!-- Specific to generate mapping between tests and covered code -->
-                        <properties>
-                            <property>
-                                <name>listener</name>
-                                <value>org.sonar.java.jacoco.JUnitListener</value>
-                            </property>
-                        </properties>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.16</version>
-                    <configuration>
-                        <argLine>-Xmx1024m -XX:MaxPermSize=256m ${jacoco.agent.it.arg}</argLine>
-                        <!-- Specific to generate mapping between tests and covered code -->
-                        <properties>
-                            <property>
-                                <name>listener</name>
-                                <value>org.sonar.java.jacoco.JUnitListener</value>
-                            </property>
-                        </properties>
-                        <!-- Let's put failsafe reports with surefire to have access to tests failures/success reports in sonar -->
-                        <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.jacoco</groupId>
-                    <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>${jacoco.version}</version>
-                    <executions>
-                        <!-- Prepares a variable, jacoco.agent.ut.arg, that contains the info to be passed to the JVM hosting the code
-being tested. -->
-                        <execution>
-                            <id>prepare-ut-agent</id>
-                            <phase>process-test-classes</phase>
-                            <goals>
-                                <goal>prepare-agent</goal>
-                            </goals>
-                            <configuration>
-                                <destFile>${sonar.jacoco.reportPath}</destFile>
-                                <propertyName>jacoco.agent.ut.arg</propertyName>
-                                <append>true</append>
-                            </configuration>
-                        </execution>
-                        <!-- Prepares a variable, jacoco.agent.it.arg, that contains the info to be passed to the JVM hosting the code
-being tested. -->
-                        <execution>
-                            <id>prepare-it-agent</id>
-                            <phase>pre-integration-test</phase>
-                            <goals>
-                                <goal>prepare-agent</goal>
-                            </goals>
-                            <configuration>
-                                <destFile>${sonar.jacoco.itReportPath}</destFile>
-                                <propertyName>jacoco.agent.it.arg</propertyName>
-                                <append>true</append>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-            </plugins>
-        </build>
-        <dependencies>
-            <dependency>
-                <groupId>org.codehaus.sonar-plugins.java</groupId>
-                <artifactId>sonar-jacoco-listeners</artifactId>
-                <version>${sonar-jacoco-listeners.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.codehaus.sonar-plugins.java</groupId>
-                <artifactId>sonar-jacoco-plugin</artifactId>
-                <version>${sonar-jacoco-plugin.version}</version>
-            </dependency>
-        </dependencies>
-    </profile>
-</profiles>
+    <!-- SONAR TEST COVERAGE PROFILE-->
+    <profiles>
+        <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.13</version>
+                        <configuration>
+                            <argLine>${jacoco.agent.ut.arg}</argLine>
+                            <!-- Specific to generate mapping between tests and covered code -->
+                            <properties>
+                                <property>
+                                    <name>listener</name>
+                                    <value>org.sonar.java.jacoco.JUnitListener</value>
+                                </property>
+                            </properties>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>2.16</version>
+                        <configuration>
+                            <argLine>-Xmx1024m -XX:MaxPermSize=256m ${jacoco.agent.it.arg}</argLine>
+                            <!-- Specific to generate mapping between tests and covered code -->
+                            <properties>
+                                <property>
+                                    <name>listener</name>
+                                    <value>org.sonar.java.jacoco.JUnitListener</value>
+                                </property>
+                            </properties>
+                            <!-- Let's put failsafe reports with surefire to have access to tests failures/success reports in sonar -->
+                            <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>${jacoco.version}</version>
+                        <executions>
+                            <!-- Prepares a variable, jacoco.agent.ut.arg, that contains the info to be passed to the JVM hosting the code
+                            being tested. -->
+                            <execution>
+                                <id>prepare-ut-agent</id>
+                                <phase>process-test-classes</phase>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                                <configuration>
+                                    <destFile>${sonar.jacoco.reportPath}</destFile>
+                                    <propertyName>jacoco.agent.ut.arg</propertyName>
+                                    <append>true</append>
+                                </configuration>
+                            </execution>
+                            <!-- Prepares a variable, jacoco.agent.it.arg, that contains the info to be passed to the JVM hosting the code
+                            being tested. -->
+                            <execution>
+                                <id>prepare-it-agent</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                                <configuration>
+                                    <destFile>${sonar.jacoco.itReportPath}</destFile>
+                                    <propertyName>jacoco.agent.it.arg</propertyName>
+                                    <append>true</append>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <dependencies>
+                <dependency>
+                    <groupId>org.codehaus.sonar-plugins.java</groupId>
+                    <artifactId>sonar-jacoco-listeners</artifactId>
+                    <version>${sonar-jacoco-listeners.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.codehaus.sonar-plugins.java</groupId>
+                    <artifactId>sonar-jacoco-plugin</artifactId>
+                    <version>${sonar-jacoco-plugin.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
 </project>

--- a/interaction-sdk-plugin/src/main/java/com/temenos/interaction/sdk/plugin/ResponderGenMojo.java
+++ b/interaction-sdk-plugin/src/main/java/com/temenos/interaction/sdk/plugin/ResponderGenMojo.java
@@ -30,6 +30,7 @@ import org.apache.maven.plugin.MojoFailureException;
 
 import com.temenos.interaction.sdk.JPAResponderGen;
 import com.temenos.interaction.sdk.adapter.edmx.EDMXAdapter;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * A Maven plugin that generates a responder from a given EDMX file.
@@ -41,22 +42,26 @@ public class ResponderGenMojo extends AbstractMojo {
     /**
      * @parameter property="edmxFile"
      */
+    @Parameter(property = "edmxFile")
     private String edmxFile;
 
     /**
      * Enable/disable strict odata compliance.
      * @parameter
      */
+    @Parameter
     private boolean strictOdata = true;
     
     /**
      * @parameter property="srcTargetDirectory"
      */
+    @Parameter(property = "srcTargetDirectory")
     private String srcTargetDirectory;
 
     /**
      * @parameter property="configTargetDirectory"
      */
+    @Parameter(property = "configTargetDirectory")
     private String configTargetDirectory;
 
 	public void setEdmxFile(String edmxFileStr) {

--- a/interaction-sdk-plugin/src/main/java/com/temenos/interaction/sdk/plugin/ResponderGenMojo.java
+++ b/interaction-sdk-plugin/src/main/java/com/temenos/interaction/sdk/plugin/ResponderGenMojo.java
@@ -41,7 +41,7 @@ public class ResponderGenMojo extends AbstractMojo {
     /**
      * @parameter property="edmxFile"
      */
-    private String edmxFileStr;
+    private String edmxFile;
 
     /**
      * Enable/disable strict odata compliance.
@@ -60,7 +60,7 @@ public class ResponderGenMojo extends AbstractMojo {
     private String configTargetDirectory;
 
 	public void setEdmxFile(String edmxFileStr) {
-		this.edmxFileStr = edmxFileStr;
+		this.edmxFile = edmxFileStr;
 	}
 
 	public void setSrcTargetDirectory(String targetDirectory) {
@@ -77,7 +77,7 @@ public class ResponderGenMojo extends AbstractMojo {
 	
 	public void execute() throws MojoExecutionException, MojoFailureException {
 		// check our configuration
-		if (edmxFileStr == null)
+		if (edmxFile == null)
 			throw new MojoExecutionException("[edmxFilePath] not specified in plugin configuration");
 		if (srcTargetDirectory == null)
 			throw new MojoExecutionException("[srcTargetDirectory] not specified in plugin configuration");
@@ -85,13 +85,13 @@ public class ResponderGenMojo extends AbstractMojo {
 			getLog().warn("[configTargetDirectory] not set, using [srcTargetDirectory]");
 			configTargetDirectory = srcTargetDirectory;
 		}
-		File edmxFile = new File(edmxFileStr);
+		File edmxFileHandle = new File(edmxFile);
 		File srcTargetDir = new File(srcTargetDirectory);
 		File configTargetDir = new File(configTargetDirectory);
-		execute(edmxFile, srcTargetDir, configTargetDir);
+		execute(edmxFileHandle, srcTargetDir, configTargetDir);
 	}
 	
-	protected void execute(File edmxFile, File srcTargetDir, File configTargetDir) throws MojoExecutionException, MojoFailureException {
+	protected void execute(File edmxFileHandle, File srcTargetDir, File configTargetDir) throws MojoExecutionException, MojoFailureException {
 		if (!srcTargetDir.exists()) {
 			getLog().info("Source target directory does not exist, creating it [" + srcTargetDirectory + "]");
 			srcTargetDir.mkdirs();
@@ -111,9 +111,9 @@ public class ResponderGenMojo extends AbstractMojo {
 
 		boolean ok = false;
 		JPAResponderGen rg = new JPAResponderGen(strictOdata);
-		if (edmxFile.exists()) {
+		if (edmxFileHandle.exists()) {
 			getLog().info("Generating artifacts (strict odata compliance: " + (strictOdata ? "true" : "false") + ")");
-			ok = rg.generateArtifacts(new EDMXAdapter(edmxFile.getAbsolutePath()), srcTargetDir, configTargetDir);
+			ok = rg.generateArtifacts(new EDMXAdapter(edmxFileHandle.getAbsolutePath()), srcTargetDir, configTargetDir);
 		}
 		else {
 			getLog().error("EDMX file does not exist.");

--- a/interaction-sdk-plugin/src/main/java/com/temenos/interaction/sdk/plugin/ResponderGenMojo.java
+++ b/interaction-sdk-plugin/src/main/java/com/temenos/interaction/sdk/plugin/ResponderGenMojo.java
@@ -30,44 +30,34 @@ import org.apache.maven.plugin.MojoFailureException;
 
 import com.temenos.interaction.sdk.JPAResponderGen;
 import com.temenos.interaction.sdk.adapter.edmx.EDMXAdapter;
+import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
  * A Maven plugin that generates a responder from a given EDMX file.
- * @goal gen
- * @requiresDependencyResolution compile
  */
+@Mojo(name = "gen",
+        requiresDependencyResolution=ResolutionScope.COMPILE)
 public class ResponderGenMojo extends AbstractMojo {
 
-    // renamed the variable, Maven 3.3 seems to ignore any hints to take config property name other than variable name it is supposed to land in
-    // see https://issues.apache.org/jira/browse/MNG-5948
-    /**
-     * @parameter property="edmxFile"
-     */
-    @Parameter(property = "edmxFile")
-    private String edmxFile;
+    @Parameter(property = "edmxFile", alias="edmxFile")
+    private String edmxFilePath;
 
     /**
      * Enable/disable strict odata compliance.
-     * @parameter
      */
     @Parameter
     private boolean strictOdata = true;
     
-    /**
-     * @parameter property="srcTargetDirectory"
-     */
     @Parameter(property = "srcTargetDirectory")
     private String srcTargetDirectory;
 
-    /**
-     * @parameter property="configTargetDirectory"
-     */
     @Parameter(property = "configTargetDirectory")
     private String configTargetDirectory;
 
-	public void setEdmxFile(String edmxFileStr) {
-		this.edmxFile = edmxFileStr;
+	public void setEdmxFile(String edmxFilePath) {
+		this.edmxFilePath = edmxFilePath;
 	}
 
 	public void setSrcTargetDirectory(String targetDirectory) {
@@ -84,7 +74,7 @@ public class ResponderGenMojo extends AbstractMojo {
 	
 	public void execute() throws MojoExecutionException, MojoFailureException {
 		// check our configuration
-		if (edmxFile == null)
+		if (edmxFilePath == null)
 			throw new MojoExecutionException("[edmxFilePath] not specified in plugin configuration");
 		if (srcTargetDirectory == null)
 			throw new MojoExecutionException("[srcTargetDirectory] not specified in plugin configuration");
@@ -92,10 +82,10 @@ public class ResponderGenMojo extends AbstractMojo {
 			getLog().warn("[configTargetDirectory] not set, using [srcTargetDirectory]");
 			configTargetDirectory = srcTargetDirectory;
 		}
-		File edmxFileHandle = new File(edmxFile);
+		File edmxFile = new File(edmxFilePath);
 		File srcTargetDir = new File(srcTargetDirectory);
 		File configTargetDir = new File(configTargetDirectory);
-		execute(edmxFileHandle, srcTargetDir, configTargetDir);
+		execute(edmxFile, srcTargetDir, configTargetDir);
 	}
 	
 	protected void execute(File edmxFileHandle, File srcTargetDir, File configTargetDir) throws MojoExecutionException, MojoFailureException {

--- a/interaction-sdk-plugin/src/main/java/com/temenos/interaction/sdk/plugin/ResponderGenMojo.java
+++ b/interaction-sdk-plugin/src/main/java/com/temenos/interaction/sdk/plugin/ResponderGenMojo.java
@@ -39,6 +39,8 @@ import org.apache.maven.plugins.annotations.Parameter;
  */
 public class ResponderGenMojo extends AbstractMojo {
 
+    // renamed the variable, Maven 3.3 seems to ignore any hints to take config property name other than variable name it is supposed to land in
+    // see https://issues.apache.org/jira/browse/MNG-5948
     /**
      * @parameter property="edmxFile"
      */


### PR DESCRIPTION
Added support for Maven 3.3 by introducing redundant annotation based Mojo configuration for ResponderGenMojo + renaming some variables to match parameter name. Looks like regression in Maven 3.3 comparing to 3.0.5, but as the above changes help - probably no point investigating into Maven.