### PR TITLE
Support application/json in HALBuilder

### DIFF
--- a/interaction-media-hal/src/main/java/com/temenos/interaction/media/hal/HALMediaType.java
+++ b/interaction-media-hal/src/main/java/com/temenos/interaction/media/hal/HALMediaType.java
@@ -1,0 +1,48 @@
+package com.temenos.interaction.media.hal;
+
+/*
+ * #%L
+ * interaction-media-hal
+ * %%
+ * Copyright (C) 2012 - 2013 Temenos Holdings N.V.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import javax.ws.rs.core.MediaType;
+
+public class HALMediaType {
+
+    /** "application/hal+xml" */
+    public final static String APPLICATION_HAL_XML = "application/hal+xml";
+    /** "application/hal+xml" */
+    public final static MediaType APPLICATION_HAL_XML_TYPE = new MediaType("application","hal+xml");
+
+    /** "application/hal+json" */
+    public final static String APPLICATION_HAL_JSON = "application/hal+json";
+    /** "application/hal+json" */
+    public final static MediaType APPLICATION_HAL_JSON_TYPE = new MediaType("application","hal+json");
+
+	public static String baseMediaType( MediaType parameterisedMediaType ) {
+		return String.format("%s/%s", parameterisedMediaType.getType(), parameterisedMediaType.getSubtype());
+	}
+	public static String charset( MediaType parameterisedMediaType, String defaultMediaType ) {
+		String specified = parameterisedMediaType.getParameters().get("charset");
+		if ( specified == null )
+			return defaultMediaType;
+		else
+			return specified;
+	}
+}

--- a/interaction-media-hal/src/test/java/com/temenos/interaction/media/hal/TestHALProvider.java
+++ b/interaction-media-hal/src/test/java/com/temenos/interaction/media/hal/TestHALProvider.java
@@ -150,6 +150,7 @@ public class TestHALProvider {
 		assertEquals(new Long(2), entity.getProperties().getProperty("age").getValue());
 	}
 	
+
 	@SuppressWarnings("unchecked")
 	@Test
 	public void testDeserialiseResolveEntityName() throws IOException, URISyntaxException {
@@ -187,6 +188,29 @@ public class TestHALProvider {
 		InputStream entityStream = new ByteArrayInputStream(strEntityStream.getBytes());
 		GenericEntity<EntityResource<Entity>> ge = new GenericEntity<EntityResource<Entity>>(new EntityResource<Entity>()) {}; 
 		EntityResource<Entity> er = (EntityResource<Entity>) hp.readFrom(RESTResource.class, ge.getType(), null, MediaType.APPLICATION_HAL_JSON_TYPE, null, entityStream);
+		assertNotNull(er.getEntity());
+		Entity entity = er.getEntity();
+		assertEquals("Children", entity.getName());
+	}
+        
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testDeserialisePlainJSON() throws IOException, URISyntaxException {
+		ResourceStateMachine sm = new ResourceStateMachine(new ResourceState("Children", "initial", new ArrayList<Action>(), "/children"));
+		HALProvider hp = new HALProvider(createMockChildVocabMetadata(), new DefaultResourceStateProvider(sm),
+										 new com.theoryinpractise.halbuilder.standard.StandardRepresentationFactory().withReader(javax.ws.rs.core.MediaType.APPLICATION_JSON, com.theoryinpractise.halbuilder.json.JsonRepresentationReader.class)
+										 );
+		UriInfo mockUriInfo = mock(UriInfo.class);
+		when(mockUriInfo.getBaseUri()).thenReturn(new URI("http://www.temenos.com/rest.svc/"));
+		hp.setUriInfo(mockUriInfo);
+		Request requestContext = mock(Request.class);
+		when(requestContext.getMethod()).thenReturn("GET");
+		hp.setRequestContext(requestContext);
+
+		String strEntityStream = "{ \"_links\": { \"self\": { \"href\": \"http://www.temenos.com/rest.svc/children\" } }, \"name\": \"noah\", \"age\": 2 }";
+		InputStream entityStream = new ByteArrayInputStream(strEntityStream.getBytes());
+		GenericEntity<EntityResource<Entity>> ge = new GenericEntity<EntityResource<Entity>>(new EntityResource<Entity>()) {}; 
+		EntityResource<Entity> er = (EntityResource<Entity>) hp.readFrom(RESTResource.class, ge.getType(), null, javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE, null, entityStream);
 		assertNotNull(er.getEntity());
 		Entity entity = er.getEntity();
 		assertEquals("Children", entity.getName());


### PR DESCRIPTION
The application/json media type was previously supported for output, but did not work for input

Simplified the media type handling generally in HALProvider. As a side-effect, the charset parameter on the media type is now properly supported.

The RepresentationFactory used by the HALProvider can now be defined in the spring configuration if non-standard behaviour is required. The default behaviour is unchanged