### PR TITLE
Fix to remove double encoding of the links. Added Unit tests to test the same.

### DIFF
--- a/interaction-core/src/main/java/com/temenos/interaction/core/hypermedia/ResourceStateMachine.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/hypermedia/ResourceStateMachine.java
@@ -1405,8 +1405,9 @@ public class ResourceStateMachine {
                         }
 					}
 				}
-
-                href = linkTemplate.buildFromMap(transitionProperties);
+                // Links in the transition properties are already encoded so 
+                // build the href using encoded map.
+                href = linkTemplate.buildFromEncodedMap(transitionProperties);
 			} else {
 				// We are NOT dealing with a dynamic target
 
@@ -1421,7 +1422,9 @@ public class ResourceStateMachine {
 					logger.debug("Building link with entity (No Transformer) [" + entity + "] [" + transition + "]");
 					href = linkTemplate.build(entity);
                 } else {
-					href = linkTemplate.buildFromMap(transitionProperties);
+                    // Links in the transition properties are already encoded so 
+                    // build the href using encoded map.
+                     href = linkTemplate.buildFromEncodedMap(transitionProperties);
 			}
             }
 


### PR DESCRIPTION
Fix to remove double encoding of the links. Added unit tests to support href's containing HTTP character entities specified in RFC 3986 except * because it's not being supported by URLEncoder.