### PR TITLE
Decoding the string resourcePath from UTF8

### DIFF
--- a/interaction-core/src/main/java/com/temenos/interaction/core/ExUriInfoImpl.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/ExUriInfoImpl.java
@@ -1,0 +1,135 @@
+package com.temenos.interaction.core;
+
+/*
+ * #%L
+ * interaction-core
+ * %%
+ * Copyright (C) 2012 - 2016 Temenos Holdings N.V.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import java.net.URI;
+import java.net.URLDecoder;
+import java.util.List;
+
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.PathSegment;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * TODO: Document me!
+ *
+ * @author clopes
+ *
+ */
+public class ExUriInfoImpl implements UriInfo {
+    
+    private UriInfo uriInfo;
+    
+    public ExUriInfoImpl(UriInfo uriInfo) {
+        this.uriInfo = uriInfo;
+    }
+
+    @Override
+    public String getPath() {
+        try {
+            return URLDecoder.decode(uriInfo.getPath(), "UTF-8");
+        } catch (Exception e) {
+            return uriInfo.getPath();
+        }
+    }
+
+    @Override
+    public String getPath(boolean decode) {
+        return uriInfo.getPath(decode);
+    }
+
+    @Override
+    public List<PathSegment> getPathSegments() {
+        return uriInfo.getPathSegments();
+    }
+
+    @Override
+    public List<PathSegment> getPathSegments(boolean decode) {
+        return uriInfo.getPathSegments(decode);
+    }
+
+    @Override
+    public URI getRequestUri() {
+        return uriInfo.getRequestUri();
+    }
+
+    @Override
+    public UriBuilder getRequestUriBuilder() {
+        return uriInfo.getRequestUriBuilder();
+    }
+
+    @Override
+    public URI getAbsolutePath() {
+        return uriInfo.getAbsolutePath();
+    }
+
+    @Override
+    public UriBuilder getAbsolutePathBuilder() {
+        return uriInfo.getAbsolutePathBuilder();
+    }
+
+    @Override
+    public URI getBaseUri() {
+        return uriInfo.getBaseUri();
+    }
+
+    @Override
+    public UriBuilder getBaseUriBuilder() {
+        return uriInfo.getBaseUriBuilder();
+    }
+
+    @Override
+    public MultivaluedMap<String, String> getPathParameters() {
+        return uriInfo.getPathParameters();
+    }
+
+    @Override
+    public MultivaluedMap<String, String> getPathParameters(boolean decode) {
+        return uriInfo.getPathParameters(decode);
+    }
+
+    @Override
+    public MultivaluedMap<String, String> getQueryParameters() {
+        return uriInfo.getQueryParameters();
+    }
+
+    @Override
+    public MultivaluedMap<String, String> getQueryParameters(boolean decode) {
+        return uriInfo.getQueryParameters(decode);
+    }
+
+    @Override
+    public List<String> getMatchedURIs() {
+        return uriInfo.getMatchedURIs();
+    }
+
+    @Override
+    public List<String> getMatchedURIs(boolean decode) {
+        return uriInfo.getMatchedURIs(decode);
+    }
+
+    @Override
+    public List<Object> getMatchedResources() {
+        return uriInfo.getMatchedResources();
+    }
+}

--- a/interaction-core/src/main/java/com/temenos/interaction/core/UriInfoImpl.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/UriInfoImpl.java
@@ -31,16 +31,16 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
 /**
- * TODO: Document me!
+ * A simple class just to be able to provide the path decoded from utf8 to the providers
  *
  * @author clopes
  *
  */
-public class ExUriInfoImpl implements UriInfo {
+public class UriInfoImpl implements UriInfo {
     
     private UriInfo uriInfo;
     
-    public ExUriInfoImpl(UriInfo uriInfo) {
+    public UriInfoImpl(UriInfo uriInfo) {
         this.uriInfo = uriInfo;
     }
 

--- a/interaction-media-hal/src/main/java/com/temenos/interaction/media/hal/HALProvider.java
+++ b/interaction-media-hal/src/main/java/com/temenos/interaction/media/hal/HALProvider.java
@@ -69,6 +69,7 @@ import org.odata4j.core.OSimpleObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.temenos.interaction.core.UriInfoImpl;
 import com.temenos.interaction.core.command.InteractionContext;
 import com.temenos.interaction.core.entity.Entity;
 import com.temenos.interaction.core.entity.EntityMetadata;
@@ -638,6 +639,7 @@ public class HALProvider implements MessageBodyReader<RESTResource>, MessageBody
 			 */
 			PushbackInputStream wrappedStream = new PushbackInputStream(entityStream);
 			int firstByte = wrappedStream.read();
+			uriInfo = new UriInfoImpl(uriInfo);
 			if ( firstByte == -1 ) {
 					// No data provided
 					return null;

--- a/interaction-media-odata-xml/src/main/java/com/temenos/interaction/media/odata/xml/atom/AtomXMLProvider.java
+++ b/interaction-media-odata-xml/src/main/java/com/temenos/interaction/media/odata/xml/atom/AtomXMLProvider.java
@@ -29,10 +29,8 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PushbackInputStream;
 import java.io.Reader;
-import java.io.UnsupportedEncodingException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -74,6 +72,7 @@ import org.odata4j.producer.Responses;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.temenos.interaction.core.ExUriInfoImpl;
 import com.temenos.interaction.core.ExtendedMediaTypes;
 import com.temenos.interaction.core.command.InteractionContext;
 import com.temenos.interaction.core.entity.Entity;
@@ -439,6 +438,8 @@ public class AtomXMLProvider implements MessageBodyReader<RESTResource>, Message
 		
 		try {
 			OEntityKey entityKey = null;
+			
+			uriInfo = new ExUriInfoImpl(uriInfo);
 
 			// work out the entity name using resource path from UriInfo
 			String baseUri = AtomXMLProvider.getBaseUri(serviceDocument, uriInfo);
@@ -524,17 +525,6 @@ public class AtomXMLProvider implements MessageBodyReader<RESTResource>, Message
 	protected ResourceState getCurrentState(ResourceState serviceDocument, String resourcePath) {
 		ResourceState state = null;
 		if (resourcePath != null) {
-		    
-		    /*
-		     * transform the encoded resourcePath putting back the original characters
-		     */
-		    try {
-                resourcePath = URLDecoder.decode(resourcePath, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                logger.warn("Cannot decode the resourcePath:" + resourcePath);
-            }
-		    
-		    
 			/*
 			 * add a leading '/' if it needs it (when defining resources we must use a 
 			 * full path, but requests can be relative, i.e. without a '/'
@@ -669,9 +659,9 @@ public class AtomXMLProvider implements MessageBodyReader<RESTResource>, Message
 		return baseUri;
 	}
 	
-	public static String getAbsolutePath(UriInfo uriInfo) {
-		return uriInfo.getBaseUri() + uriInfo.getPath();
-	}
+    public static String getAbsolutePath(UriInfo uriInfo) {
+        return uriInfo.getBaseUri() + uriInfo.getPath();
+    }
 	
 	private EdmDataServices getEdmDataService() {
 		return metadataOData4j.getMetadata();

--- a/interaction-media-odata-xml/src/main/java/com/temenos/interaction/media/odata/xml/atom/AtomXMLProvider.java
+++ b/interaction-media-odata-xml/src/main/java/com/temenos/interaction/media/odata/xml/atom/AtomXMLProvider.java
@@ -29,8 +29,10 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PushbackInputStream;
 import java.io.Reader;
+import java.io.UnsupportedEncodingException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -522,6 +524,17 @@ public class AtomXMLProvider implements MessageBodyReader<RESTResource>, Message
 	protected ResourceState getCurrentState(ResourceState serviceDocument, String resourcePath) {
 		ResourceState state = null;
 		if (resourcePath != null) {
+		    
+		    /*
+		     * transform the encoded resourcePath putting back the original characters
+		     */
+		    try {
+                resourcePath = URLDecoder.decode(resourcePath, "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                logger.warn("Cannot decode the resourcePath:" + resourcePath);
+            }
+		    
+		    
 			/*
 			 * add a leading '/' if it needs it (when defining resources we must use a 
 			 * full path, but requests can be relative, i.e. without a '/'

--- a/interaction-media-odata-xml/src/main/java/com/temenos/interaction/media/odata/xml/atom/AtomXMLProvider.java
+++ b/interaction-media-odata-xml/src/main/java/com/temenos/interaction/media/odata/xml/atom/AtomXMLProvider.java
@@ -72,7 +72,7 @@ import org.odata4j.producer.Responses;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.temenos.interaction.core.ExUriInfoImpl;
+import com.temenos.interaction.core.UriInfoImpl;
 import com.temenos.interaction.core.ExtendedMediaTypes;
 import com.temenos.interaction.core.command.InteractionContext;
 import com.temenos.interaction.core.entity.Entity;
@@ -439,7 +439,7 @@ public class AtomXMLProvider implements MessageBodyReader<RESTResource>, Message
 		try {
 			OEntityKey entityKey = null;
 			
-			uriInfo = new ExUriInfoImpl(uriInfo);
+			uriInfo = new UriInfoImpl(uriInfo);
 
 			// work out the entity name using resource path from UriInfo
 			String baseUri = AtomXMLProvider.getBaseUri(serviceDocument, uriInfo);
@@ -659,9 +659,9 @@ public class AtomXMLProvider implements MessageBodyReader<RESTResource>, Message
 		return baseUri;
 	}
 	
-    public static String getAbsolutePath(UriInfo uriInfo) {
-        return uriInfo.getBaseUri() + uriInfo.getPath();
-    }
+	public static String getAbsolutePath(UriInfo uriInfo) {
+		return uriInfo.getBaseUri() + uriInfo.getPath();
+	}
 	
 	private EdmDataServices getEdmDataService() {
 		return metadataOData4j.getMetadata();

--- a/interaction-media-odata-xml/src/test/java/com/temenos/interaction/media/odata/xml/atom/TestAtomXMLProvider.java
+++ b/interaction-media-odata-xml/src/test/java/com/temenos/interaction/media/odata/xml/atom/TestAtomXMLProvider.java
@@ -25,6 +25,7 @@ package com.temenos.interaction.media.odata.xml.atom;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -38,6 +39,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.lang.annotation.Annotation;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -1690,5 +1692,36 @@ public class TestAtomXMLProvider {
 		assertEquals("123456", debitLink.getLinkId());
 		assertEquals("654321", creditLink.getLinkId());
 	}
-
+	
+	@Test
+    public void testGetAbsolutePath() throws URISyntaxException, UnsupportedEncodingException {
+	    
+	    String pathDecoded = "resourceTest('1234://ABC')";
+	    String pathEncodedUTF8 = new String(pathDecoded.getBytes("UTF-8"), "UTF-8");
+	    String pathEncodedWrong = new String(pathDecoded.getBytes("UTF-8"), "x-UTF-16LE-BOM");
+	    
+	    String absPath = null;
+	    
+	    UriInfo uriInfo = mock(UriInfo.class);
+	    URI uri = new URI("");
+	    when(uriInfo.getBaseUri()).thenReturn(uri);
+	    
+	    // Test encoded string utf8
+	    when(uriInfo.getPath()).thenReturn(pathEncodedUTF8);	    
+	    absPath = AtomXMLProvider.getAbsolutePath(uriInfo);
+	    assertNotNull(absPath);
+	    assertEquals(pathDecoded, absPath);
+	    
+	    // Test encoded string utf16
+	    when(uriInfo.getPath()).thenReturn(pathEncodedWrong);
+        absPath = AtomXMLProvider.getAbsolutePath(uriInfo);
+        assertNotNull(absPath);
+        assertNotSame(pathDecoded, absPath);
+        
+        // Test encoded null string
+        when(uriInfo.getPath()).thenReturn(null);
+        absPath = AtomXMLProvider.getAbsolutePath(uriInfo);
+        assertNotNull(absPath);
+        assertEquals("null", absPath);
+	}
 }


### PR DESCRIPTION
In case of the string have special characters encoded, this revert the encoded received to the original form. This is needed because, to find a proper state in the resource state machine, its used string compare.