### PR TITLE
Missing drill downs under payment information.

### DIFF
--- a/interaction-media-odata-xml/src/main/java/com/temenos/interaction/media/odata/xml/atom/ODataLinkInterceptor.java
+++ b/interaction-media-odata-xml/src/main/java/com/temenos/interaction/media/odata/xml/atom/ODataLinkInterceptor.java
@@ -90,16 +90,18 @@ public class ODataLinkInterceptor implements LinkInterceptor {
 			Link firstInstance = null;
 			for (Link link : resource.getLinks()) {
 				if(link != null) {
-					// is this the first instance of this rel/href combination
+					// is this the first instance of this rel/id/href combination.
 					if (firstInstance != null
 							&& !firstInstance.equals(result)
 							&& rel.equals(link.getRel())
-							&& result.getHref().equals(link.getHref())) {
+							&& result.getHref().equals(link.getHref())
+							&& result.getId().equals(link.getId())) {
 						result = null;
 						break;
 					}
-					if (result.getRel().equals(link.getRel())
-							&& result.getHref().equals(link.getHref())) {
+					if (result.getRel().equals(link.getRel())			        
+							&& result.getHref().equals(link.getHref())
+							&& result.getId().equals(link.getId())) {
 						firstInstance = link;
 					}
 				}

--- a/interaction-media-odata-xml/src/test/java/com/temenos/interaction/media/odata/xml/atom/TestAtomXMLProvider.java
+++ b/interaction-media-odata-xml/src/test/java/com/temenos/interaction/media/odata/xml/atom/TestAtomXMLProvider.java
@@ -688,6 +688,7 @@ public class TestAtomXMLProvider {
 					.title("title")
 					.rel("self")
 					.href("href")
+					.id("id")
 					.build());
 		EntityResource<OEntity> entityResource = new EntityResource<OEntity>(mock(OEntity.class));
 		entityResource.setLinks(links);
@@ -701,6 +702,7 @@ public class TestAtomXMLProvider {
 					.title("title")
 					.rel("edit")
 					.href("href")
+					.id("id")
 					.build());
 		entityResource.setLinks(links);
 		provider.processLinks(entityResource);


### PR DESCRIPTION
Due to over enthusiastic removal of duplicate links when they have same HRef and Rel but different Id (See RTC 1674338).