### PR TITLE
Fixing class cast exception on datetime type handling in atom xml

### DIFF
--- a/interaction-media-odata-xml/src/main/java/com/temenos/interaction/media/odata/xml/atom/AtomEntityEntryFormatWriter.java
+++ b/interaction-media-odata-xml/src/main/java/com/temenos/interaction/media/odata/xml/atom/AtomEntityEntryFormatWriter.java
@@ -22,12 +22,9 @@ package com.temenos.interaction.media.odata.xml.atom;
  */
 
 import java.io.Writer;
-import java.text.SimpleDateFormat;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.TimeZone;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriInfo;
@@ -322,10 +319,7 @@ public class AtomEntityEntryFormatWriter {
 		}
 		//Write the property text
 		if(type.equals(EdmSimpleType.DATETIME) && !elementText.isEmpty()) {
-			//Write dates in UTC format
-			SimpleDateFormat formatUTC = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-			formatUTC.setTimeZone(TimeZone.getTimeZone("UTC"));
-			writer.writeElementText(formatUTC.format((Date) property.getValue()));
+			writer.writeElementText(AtomXMLProviderHelper.checkAndConvertDateTimeToUTC(property));
 		}		
 		else if (elementText != null) {
 			writer.writeElementText(elementText);
@@ -395,4 +389,5 @@ public class AtomEntityEntryFormatWriter {
 			}
 		};
 	}
+	
 }

--- a/interaction-media-odata-xml/src/main/java/com/temenos/interaction/media/odata/xml/atom/AtomXMLProviderHelper.java
+++ b/interaction-media-odata-xml/src/main/java/com/temenos/interaction/media/odata/xml/atom/AtomXMLProviderHelper.java
@@ -1,0 +1,50 @@
+package com.temenos.interaction.media.odata.xml.atom;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+import org.joda.time.LocalDateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.temenos.interaction.core.entity.EntityProperty;
+
+/**
+ * Utility class for Atom XML provider.
+ * 
+ * @author ssethupathi
+ *
+ */
+public class AtomXMLProviderHelper {
+
+	private final static Logger logger = LoggerFactory
+			.getLogger(AtomXMLProviderHelper.class);
+
+	/**
+	 * Checks the property value type and does format the date time value to UTC
+	 * accordingly.
+	 * 
+	 * @param property
+	 *            entity property
+	 * @return date time in UTC
+	 */
+	public static String checkAndConvertDateTimeToUTC(EntityProperty property) {
+		Object propertyValue = property.getValue();
+		SimpleDateFormat formatUTC = new SimpleDateFormat(
+				"yyyy-MM-dd'T'HH:mm:ss");
+		formatUTC.setTimeZone(TimeZone.getTimeZone("UTC"));
+		if (propertyValue instanceof Date) {
+			return formatUTC.format((Date) propertyValue);
+		} else if (propertyValue instanceof LocalDateTime) {
+			return formatUTC.format(((LocalDateTime) propertyValue)
+					.toDateTime().toDate());
+		} else {
+			String errorMessage = "Unsupported value type '"
+					+ propertyValue.getClass().getName() + "' for property '"
+					+ property.getFullyQualifiedName() + "'";
+			logger.error(errorMessage);
+			throw new RuntimeException(errorMessage);
+		}
+	}
+}

--- a/interaction-media-odata-xml/src/main/java/com/temenos/interaction/media/odata/xml/atom/AtomXMLProviderHelper.java
+++ b/interaction-media-odata-xml/src/main/java/com/temenos/interaction/media/odata/xml/atom/AtomXMLProviderHelper.java
@@ -1,5 +1,27 @@
 package com.temenos.interaction.media.odata.xml.atom;
 
+/*
+ * #%L
+ * interaction-media-odata-xml
+ * %%
+ * Copyright (C) 2012 - 2016 Temenos Holdings N.V.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;

--- a/interaction-media-odata-xml/src/test/java/com/temenos/interaction/media/odata/xml/atom/AtomXMLProviderHelperTest.java
+++ b/interaction-media-odata-xml/src/test/java/com/temenos/interaction/media/odata/xml/atom/AtomXMLProviderHelperTest.java
@@ -1,0 +1,56 @@
+package com.temenos.interaction.media.odata.xml.atom;
+
+import static org.junit.Assert.*;
+
+import java.text.SimpleDateFormat;
+import java.util.TimeZone;
+
+import org.joda.time.LocalDateTime;
+import org.junit.Test;
+
+import com.temenos.interaction.core.entity.EntityProperty;
+
+public class AtomXMLProviderHelperTest {
+
+	@Test
+	public void checkAndConvertDateTimeToUTCFromNonUTCDate() throws Exception {
+		SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+		format.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
+		EntityProperty property = new EntityProperty("dateOfBirth",
+				format.parse("2015-12-31T16:10:00"));
+		assertEquals("2016-01-01T00:10:00",
+				AtomXMLProviderHelper.checkAndConvertDateTimeToUTC(property));
+	}
+
+	@Test
+	public void checkAndConvertDateTimeToUTCFromUTCDate() throws Exception {
+		SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+		format.setTimeZone(TimeZone.getTimeZone("UTC"));
+		EntityProperty property = new EntityProperty("dateOfBirth",
+				format.parse("2015-12-31T16:10:00"));
+		assertEquals("2015-12-31T16:10:00",
+				AtomXMLProviderHelper.checkAndConvertDateTimeToUTC(property));
+	}
+
+	@Test
+	public void checkAndConvertDateTimeToUTCFromLocalJodaDate()
+			throws Exception {
+		LocalDateTime ldt = new LocalDateTime(2015, 12, 31, 16, 10, 0);
+		EntityProperty property = new EntityProperty("dateOfBirth", ldt);
+		assertEquals("2015-12-31T16:10:00",
+				AtomXMLProviderHelper.checkAndConvertDateTimeToUTC(property));
+	}
+
+	@Test
+	public void checkAndConvertDateTimeToUTCFromInvalidType()
+			throws Exception {
+		try {
+			AtomXMLProviderHelper
+					.checkAndConvertDateTimeToUTC(new EntityProperty(
+							"dateOfBirth", "some string object"));
+			fail("RuntimeException should be thrown");
+		} catch (Exception e) {
+			assertTrue(e instanceof RuntimeException);
+		}
+	}
+}

--- a/interaction-media-odata-xml/src/test/java/com/temenos/interaction/media/odata/xml/atom/AtomXMLProviderHelperTest.java
+++ b/interaction-media-odata-xml/src/test/java/com/temenos/interaction/media/odata/xml/atom/AtomXMLProviderHelperTest.java
@@ -1,5 +1,27 @@
 package com.temenos.interaction.media.odata.xml.atom;
 
+/*
+ * #%L
+ * interaction-media-odata-xml
+ * %%
+ * Copyright (C) 2012 - 2016 Temenos Holdings N.V.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+
 import static org.junit.Assert.*;
 
 import java.text.SimpleDateFormat;


### PR DESCRIPTION
The class cast exception has been happening in the integration tests as the JPAProducer always produces with entities with joda LocalDateTime as the type but the casting is always to java util Date.