### PR TITLE
Fix the LazyResourceDelegate to force the usage of the non decode path

### DIFF
--- a/interaction-winkext/src/main/java/com/temenos/interaction/winkext/LazyResourceDelegate.java
+++ b/interaction-winkext/src/main/java/com/temenos/interaction/winkext/LazyResourceDelegate.java
@@ -135,7 +135,7 @@ public class LazyResourceDelegate implements HTTPResourceInteractionModel, Dynam
     }
 	
 	private HTTPHypermediaRIM getResource(UriInfo uriInfo, String httpMethod) throws MethodNotAllowedException {
-        ResourceState resourceState = resourceStateProvider.getResourceState(httpMethod, "/" + uriInfo.getPath());
+        ResourceState resourceState = resourceStateProvider.getResourceState(httpMethod, "/" + uriInfo.getPath(false));
         
         if(resourceState == null) {
         	return null;

--- a/interaction-winkext/src/test/java/com/temenos/interaction/winkext/TestLazyResourceDelegate.java
+++ b/interaction-winkext/src/test/java/com/temenos/interaction/winkext/TestLazyResourceDelegate.java
@@ -97,7 +97,7 @@ public class TestLazyResourceDelegate {
         UriInfo uriInfo = mock(UriInfo.class);
         when(uriInfo.getPathParameters(eq(false))).thenReturn(mock(MultivaluedMap.class));
         when(uriInfo.getQueryParameters(eq(false))).thenReturn(mock(MultivaluedMap.class));        
-        when(uriInfo.getPath()).thenReturn("myResource");
+        when(uriInfo.getPath(eq(false))).thenReturn("myResource");
         
         lazyResourceDelegate.get(headers, id, uriInfo);
         
@@ -106,7 +106,7 @@ public class TestLazyResourceDelegate {
         uriInfo = mock(UriInfo.class);
         when(uriInfo.getPathParameters(eq(false))).thenReturn(mock(MultivaluedMap.class));
         when(uriInfo.getQueryParameters(eq(false))).thenReturn(mock(MultivaluedMap.class));        
-        when(uriInfo.getPath()).thenReturn("");
+        when(uriInfo.getPath(eq(false))).thenReturn("");
         
         lazyResourceDelegate.get(headers, id, uriInfo);
         
@@ -140,7 +140,7 @@ public class TestLazyResourceDelegate {
 		UriInfo uriInfo = mock(UriInfo.class);
         when(uriInfo.getPathParameters(eq(false))).thenReturn(mock(MultivaluedMap.class));	
         when(uriInfo.getQueryParameters(eq(false))).thenReturn(mock(MultivaluedMap.class));        
-		when(uriInfo.getPath()).thenReturn("myResource");
+		when(uriInfo.getPath(eq(false))).thenReturn("myResource");
 		EntityResource resource = mock(EntityResource.class);
 	
 		lazyResourceDelegate.post(headers, id, uriInfo, resource);
@@ -177,7 +177,7 @@ public class TestLazyResourceDelegate {
         UriInfo uriInfo = mock(UriInfo.class);
         when(uriInfo.getPathParameters(eq(false))).thenReturn(mock(MultivaluedMap.class));     
         when(uriInfo.getQueryParameters(eq(false))).thenReturn(mock(MultivaluedMap.class));        
-        when(uriInfo.getPath()).thenReturn("myResource");
+        when(uriInfo.getPath(eq(false))).thenReturn("myResource");
         
         InMultiPart inMP = mock(InMultiPart.class);        
         lazyResourceDelegate.post(headers, uriInfo, inMP);
@@ -213,7 +213,7 @@ public class TestLazyResourceDelegate {
         UriInfo uriInfo = mock(UriInfo.class);
         when(uriInfo.getPathParameters(eq(false))).thenReturn(mock(MultivaluedMap.class)); 
         when(uriInfo.getQueryParameters(eq(false))).thenReturn(mock(MultivaluedMap.class));        
-        when(uriInfo.getPath()).thenReturn("myResource");
+        when(uriInfo.getPath(eq(false))).thenReturn("myResource");
         EntityResource resource = mock(EntityResource.class);
         
         lazyResourceDelegate.put(headers, id, uriInfo, resource);  
@@ -248,7 +248,7 @@ public class TestLazyResourceDelegate {
         UriInfo uriInfo = mock(UriInfo.class);
         when(uriInfo.getPathParameters(eq(false))).thenReturn(mock(MultivaluedMap.class));    
         when(uriInfo.getQueryParameters(eq(false))).thenReturn(mock(MultivaluedMap.class));        
-        when(uriInfo.getPath()).thenReturn("myResource");
+        when(uriInfo.getPath(eq(false))).thenReturn("myResource");
         EntityResource resource = mock(EntityResource.class);
         
         lazyResourceDelegate.delete(headers, id, uriInfo);  
@@ -283,7 +283,7 @@ public class TestLazyResourceDelegate {
         UriInfo uriInfo = mock(UriInfo.class);
         when(uriInfo.getPathParameters(eq(false))).thenReturn(mock(MultivaluedMap.class));     
         when(uriInfo.getQueryParameters(eq(false))).thenReturn(mock(MultivaluedMap.class));                
-        when(uriInfo.getPath()).thenReturn("myResource");
+        when(uriInfo.getPath(eq(false))).thenReturn("myResource");
         EntityResource resource = mock(EntityResource.class);
         
         lazyResourceDelegate.options(headers, id, uriInfo);  
@@ -320,7 +320,7 @@ public class TestLazyResourceDelegate {
         UriInfo uriInfo = mock(UriInfo.class);
         when(uriInfo.getPathParameters(eq(false))).thenReturn(mock(MultivaluedMap.class));    
         when(uriInfo.getQueryParameters(eq(false))).thenReturn(mock(MultivaluedMap.class));        
-        when(uriInfo.getPath()).thenReturn("myResource");
+        when(uriInfo.getPath(eq(false))).thenReturn("myResource");
         
         InMultiPart inMP = mock(InMultiPart.class);        
         lazyResourceDelegate.put(headers, uriInfo, inMP);

--- a/interaction-winkext/src/test/java/com/temenos/interaction/winkext/TestLazyServiceRootFactory.java
+++ b/interaction-winkext/src/test/java/com/temenos/interaction/winkext/TestLazyServiceRootFactory.java
@@ -89,7 +89,7 @@ public class TestLazyServiceRootFactory {
         HttpHeaders headers = mock(HttpHeaders.class);
         String id = "123";		
         UriInfo uriInfo = mock(UriInfo.class);	
-        when(uriInfo.getPath()).thenReturn("test");
+        when(uriInfo.getPath(eq(false))).thenReturn("test");
         when(uriInfo.getPathParameters(eq(false))).thenReturn(mock(MultivaluedMap.class));   
         when(uriInfo.getQueryParameters(eq(false))).thenReturn(mock(MultivaluedMap.class));        
 
@@ -151,7 +151,7 @@ public class TestLazyServiceRootFactory {
         HttpHeaders headers = mock(HttpHeaders.class);
         String id = "123";      
         UriInfo uriInfo = mock(UriInfo.class);  
-        when(uriInfo.getPath()).thenReturn("test");
+        when(uriInfo.getPath(eq(false))).thenReturn("test");
         when(uriInfo.getPathParameters(eq(false))).thenReturn(mock(MultivaluedMap.class));   
         when(uriInfo.getQueryParameters(eq(false))).thenReturn(mock(MultivaluedMap.class));        
         


### PR DESCRIPTION
Fix the LazyResourceDelegate method getResource to resolve the resource state without decoding the uri path.

This avoids the problem when IRIS receives an URL with a parameter that contains special characters encoded like "/".