### PR TITLE
Throw RuntimeException if encoding is unsupported

### DIFF
--- a/interaction-core/src/main/java/com/temenos/interaction/core/rim/HeaderHelper.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/rim/HeaderHelper.java
@@ -47,6 +47,7 @@ import org.slf4j.LoggerFactory;
 public class HeaderHelper {
     
     private static final Logger logger = LoggerFactory.getLogger(HeaderHelper.class);
+    private static final String DEFAULT_ENCODING = "UTF-8";
 
     /**
      * Add an HTTP Allow header to the response.
@@ -167,23 +168,15 @@ public class HeaderHelper {
     
     private static String constructQueryKeyValuePairing(String key, List<String> values, boolean appendAmpersand) {
         StringBuilder sb = new StringBuilder();
-        String generatedQueryParam = "";
         int index = 0;
         for(String value : values){
-            try{
-                generatedQueryParam = key+"="+value;
-                sb.append(encodeQueryParameter(key));
-                sb.append("=");
-                sb.append(encodeQueryParameter(value));
-                if(index < values.size() - 1){
-                    sb.append("&");
-                }
-                index++;
-            }catch(UnsupportedEncodingException uee){
-                logger.error("Unable to decode query parameter {}; "
-                        + "this will be omitted.", generatedQueryParam);
-                index++;
+            sb.append(encodeQueryParameter(key, DEFAULT_ENCODING));
+            sb.append("=");
+            sb.append(encodeQueryParameter(value, DEFAULT_ENCODING));
+            if(index < values.size() - 1){
+                sb.append("&");
             }
+            index++;
         }
         if(appendAmpersand && sb.length() > 0){
             sb.append("&");
@@ -191,8 +184,14 @@ public class HeaderHelper {
         return sb.toString();
     }
     
-    private static String encodeQueryParameter(String queryParam) throws UnsupportedEncodingException{
-        return URLEncoder.encode(queryParam, "UTF-8");
+    private static String encodeQueryParameter(String queryParam, String encoding){
+        try{
+            return URLEncoder.encode(queryParam, encoding);
+        }catch(UnsupportedEncodingException uee){
+            logger.error("Unsupported encoding type {} used to encode {}",
+                    encoding, queryParam);
+            throw new RuntimeException(uee);
+        }
     }
 
 }

--- a/interaction-core/src/test/java/com/temenos/interaction/core/rim/TestHeaderHelper.java
+++ b/interaction-core/src/test/java/com/temenos/interaction/core/rim/TestHeaderHelper.java
@@ -29,7 +29,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
 
 import java.io.UnsupportedEncodingException;
 import java.util.HashSet;
@@ -184,28 +183,8 @@ public class TestHeaderHelper {
         );
     }
     
-    @Test
-    public void testEncodeQueryParametersURLEncoderThrowsException() throws Exception{
-        PowerMockito.spy(HeaderHelper.class);
-        PowerMockito.doThrow(new UnsupportedEncodingException()).when(
-                HeaderHelper.class, "encodeQueryParameter", eq("customerName")
-        );
-        MultivaluedMap<String, String> values = new MultivaluedMapImpl<String>();
-        values.add("customerNam=", "J&ck");
-        values.add("customerName", "Jack");
-        values.add("customerName", "Jill");
-        values.add("trans&ction", "!0!");
-        String queryParam = HeaderHelper.encodeMultivalueQueryParameters(values);
-        assertThat(queryParam, allOf(
-                startsWith("?"),
-                containsString("customerNam%3D=J%26ck"),
-                containsString("trans%26ction=%210%21")
-        ));
-        assertThat(StringUtils.countMatches(queryParam, "&"), equalTo(1));
-    }
-    
-    @Test
-    public void testEncodeQueryParametersURLEncoderAlwaysThrowsExceptions() throws Exception {
+    @Test(expected = RuntimeException.class)
+    public void testEncodeQueryParametersURLEncoderThrowsException() throws Exception {
         PowerMockito.spy(HeaderHelper.class);
         PowerMockito.doThrow(new UnsupportedEncodingException()).when(
                 HeaderHelper.class, "encodeQueryParameter", anyString()
@@ -215,7 +194,6 @@ public class TestHeaderHelper {
         values.add("customerName", "Jack");
         values.add("customerName", "Jill");
         values.add("trans&ction", "!0!");
-        String queryParam = HeaderHelper.encodeMultivalueQueryParameters(values);
-        assertThat(queryParam, equalTo(""));
+        HeaderHelper.encodeMultivalueQueryParameters(values);
     }
 }


### PR DESCRIPTION
This change has been made to prevent IRIS from rendering an incomplete
location header.