### PR TITLE
Prepend ? or & to query parameters

### DIFF
--- a/interaction-core/src/main/java/com/temenos/interaction/core/rim/HeaderHelper.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/rim/HeaderHelper.java
@@ -85,9 +85,12 @@ public class HeaderHelper {
      * @param queryParam
      * @return
      */
-    public static ResponseBuilder locationHeader(ResponseBuilder rb, String target, MultivaluedMap<String, String> queryParam) {
-        if (target != null && queryParam != null) {
-            return rb.header(HttpHeaders.LOCATION, target + encodeMultivalueQueryParameters(queryParam));
+    public static ResponseBuilder locationHeader(ResponseBuilder rb, String target, 
+            MultivaluedMap<String, String> queryParam) {
+        if (target != null && !isNullOrEmpty(queryParam) && target.indexOf("?") != -1) {
+            return rb.header(HttpHeaders.LOCATION, target + "&" + encodeMultivalueQueryParameters(queryParam));
+        }else if(target != null && !isNullOrEmpty(queryParam)){
+            return rb.header(HttpHeaders.LOCATION, target + "?" + encodeMultivalueQueryParameters(queryParam));
         }else if(target != null){
             return rb.header(HttpHeaders.LOCATION, target);
         }else{
@@ -148,14 +151,11 @@ public class HeaderHelper {
             filter.clear();
             outerIndex++;
         }
-        if(sb.length() > 0){
-            sb.insert(0, "?");
-        }
         return sb.toString();
     }
     
     private static boolean isNullOrEmpty(MultivaluedMap<String, String> queryParam){
-        return queryParam == null || queryParam.isEmpty();
+        return queryParam == null || queryParam.size() == 0;
     }
     
     private static void filterDuplicateQueryKeyValuePairings(List<String> src, List<String> dest){

--- a/interaction-core/src/test/java/com/temenos/interaction/core/rim/TestHeaderHelper.java
+++ b/interaction-core/src/test/java/com/temenos/interaction/core/rim/TestHeaderHelper.java
@@ -24,7 +24,6 @@ package com.temenos.interaction.core.rim;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.StringContains.containsString;
-import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
@@ -103,6 +102,22 @@ public class TestHeaderHelper {
 	}
 	
 	@Test
+	public void testLocationWithQueryParam(){
+	    MultivaluedMap<String, String> values = new MultivaluedMapImpl<String>();
+	    values.add("transactionId", "101");
+	    Response r = HeaderHelper.locationHeader(Response.ok(), "/path?customerName=Jack", values).build();
+	    assertThat((String)r.getMetadata().getFirst("Location"), containsString("?customerName=Jack&transactionId=101"));
+	}
+	
+	@Test
+    public void testLocationWithoutQueryParam(){
+        MultivaluedMap<String, String> values = new MultivaluedMapImpl<String>();
+        values.add("transactionId", "101");
+        Response r = HeaderHelper.locationHeader(Response.ok(), "/path", values).build();
+        assertThat((String)r.getMetadata().getFirst("Location"), containsString("?transactionId=101"));
+    }
+	
+	@Test
 	public void testEtag() {
 		Response r = HeaderHelper.etagHeader(Response.ok(), "ABCDEFG").build();
 		assertEquals("ABCDEFG", r.getMetadata().getFirst(HttpHeaders.ETAG));
@@ -134,12 +149,12 @@ public class TestHeaderHelper {
         values.add("transaction", "101");
         String queryParam = HeaderHelper.encodeMultivalueQueryParameters(values);
         assertThat(queryParam, allOf(
-                startsWith("?"),
                 containsString("customerName=Jack"),
                 containsString("customerName=Jill"),
                 containsString("transaction=101")
         ));
         assertThat(StringUtils.countMatches(queryParam, "&"), equalTo(2));
+        assertThat(StringUtils.countMatches(queryParam, "?"), equalTo(0));
     }
     
     @Test
@@ -151,7 +166,6 @@ public class TestHeaderHelper {
         values.add("transaction", "102");
         String queryParam = HeaderHelper.encodeMultivalueQueryParameters(values);
         assertThat(queryParam, allOf(
-                startsWith("?"),
                 containsString("customerName=Jack"),
                 containsString("transaction=101"),
                 containsString("transaction=102")
@@ -167,7 +181,6 @@ public class TestHeaderHelper {
         values.add("trans&ction", "!0!");
         String queryParam = HeaderHelper.encodeMultivalueQueryParameters(values);
         assertThat(queryParam, allOf(
-                startsWith("?"),
                 containsString("customerNam%3D=J%26ck"),
                 containsString("trans%26ction=%210%21")
         ));


### PR DESCRIPTION
HeaderHelper now prepends either a & or a ? depending on whether the
incoming target URL already has query parameters or not.