### PR TITLE
interaction-odata4j-ext fix for consume all the links (with any relation)

### DIFF
--- a/interaction-odata4j-ext/src/main/java/org/odata4j/format/xml/AtomFeedFormatParserExt.java
+++ b/interaction-odata4j-ext/src/main/java/org/odata4j/format/xml/AtomFeedFormatParserExt.java
@@ -30,6 +30,7 @@ import java.util.List;
 import javax.ws.rs.core.MediaType;
 import javax.xml.stream.XMLInputFactory;
 
+import org.apache.commons.lang.StringUtils;
 import org.core4j.Enumerable;
 import org.core4j.Func1;
 import org.odata4j.core.OCollection;
@@ -388,7 +389,7 @@ public class AtomFeedFormatParserExt extends AtomFeedFormatParser {
 		    List<OLink> rt = new ArrayList<OLink>(links.size());
 		    for (final AtomLink link : links) {
 
-		      if (link.relation.startsWith(XmlFormatWriter.related)) {
+		      if (!StringUtils.isEmpty(link.relation)) {
 		        if (link.type.equals(XmlFormatWriter.atom_feed_content_type)) {
 
 		          if (link.inlineContentExpected) {

--- a/interaction-odata4j-ext/src/test/java/org/odata4j/format/xml/AtomFeedFormatParserExtTest.java
+++ b/interaction-odata4j-ext/src/test/java/org/odata4j/format/xml/AtomFeedFormatParserExtTest.java
@@ -146,6 +146,8 @@ public class AtomFeedFormatParserExtTest {
 		assertNotNull(entry);
 		OEntity entity = entry.getEntity();
 		assertNotNull(entity);
+		assertNotNull(entity.getLinks());
+		assertTrue(entity.getLinks().size() > 0);
 
 		// We can add more asserts here to verify each OProperty
 

--- a/interaction-odata4j-ext/src/test/java/org/odata4j/format/xml/AtomFeedFormatParserExtTest.java
+++ b/interaction-odata4j-ext/src/test/java/org/odata4j/format/xml/AtomFeedFormatParserExtTest.java
@@ -147,7 +147,7 @@ public class AtomFeedFormatParserExtTest {
 		OEntity entity = entry.getEntity();
 		assertNotNull(entity);
 		assertNotNull(entity.getLinks());
-		assertTrue(entity.getLinks().size() > 0);
+		assertTrue(!entity.getLinks().isEmpty());
 
 		// We can add more asserts here to verify each OProperty
 


### PR DESCRIPTION
All odata link flowing into the IRIS response should be consumed while using the extended the Odata4j-ext library