### PR TITLE
Content type for atom xml self link

### DIFF
--- a/useragent-generic-java/src/main/java/com/temenos/useragent/generic/mediatype/AtomLinkHandler.java
+++ b/useragent-generic-java/src/main/java/com/temenos/useragent/generic/mediatype/AtomLinkHandler.java
@@ -111,13 +111,14 @@ public class AtomLinkHandler {
 				content = getContent(entryElement);
 			}
 		}
+		
+		String contentType = abderaLink.getAttributeValue("type")!=null?abderaLink.getAttributeValue("type"):AtomUtil.MEDIA_TYPE;
 		PayloadHandlerFactory<? extends PayloadHandler> factory = ContextFactory
 				.get()
 				.getContext()
 				.entityHandlersRegistry()
 				.getPayloadHandlerFactory(
-						DefaultHttpClientHelper.removeParameter(abderaLink
-								.getAttributeValue("type")));
+						DefaultHttpClientHelper.removeParameter(contentType));
 		PayloadHandler handler = factory.createHandler(content);
 		PayloadWrapper wrapper = new DefaultPayloadWrapper();
 		wrapper.setHandler(handler);

--- a/useragent-generic-java/src/test/java/com/temenos/useragent/generic/mediatype/AtomLinkHandlerTest.java
+++ b/useragent-generic-java/src/test/java/com/temenos/useragent/generic/mediatype/AtomLinkHandlerTest.java
@@ -37,6 +37,7 @@ public class AtomLinkHandlerTest {
     
     private static final String TEST_DATA = "/atom_entry_with_link_embedded.txt";
     private static final String TEST_EMPTY_INLINE_LINK_DATA = "/atom_entry_with_embedded_empty_inline_link.txt";
+    private static final String TEST_INLINE_SELF_LINK_DATA = "/atom_entry_with_embedded_self_link.txt";
 
 	private Entry testEntry;
 
@@ -133,6 +134,15 @@ public class AtomLinkHandlerTest {
 		Payload embeddedErrors = errorsLinkHandler.getEmbeddedPayload();
 		assertNotNull(embeddedErrors.links().get(0).baseUrl());
 	}
+    
+    @Test
+    public void testGetEmbeddedSelfLink() {
+    	testEntry = loadTestEntry(TEST_INLINE_SELF_LINK_DATA);
+    	AtomLinkHandler selfLinkHandler = new AtomLinkHandler(
+				testEntry.getLink("self"));
+		Payload selfPayload = selfLinkHandler.getEmbeddedPayload();
+		assertNotNull(selfPayload);
+    }
     
 	private Entry loadTestEntry(String resource) {
 		Entry entry = new Abdera()

--- a/useragent-generic-java/src/test/resources/atom_entry_with_embedded_self_link.txt
+++ b/useragent-generic-java/src/test/resources/atom_entry_with_embedded_self_link.txt
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='utf-8'?>
+<entry xmlns="http://www.w3.org/2005/Atom" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xml:base="http://localhost:9089/t24interactiontests-iris/t24interactiontests.svc/GB0010001/">
+	<id>http://localhost:9089/t24interactiontests-iris/t24interactiontests.svc/GB0010001/verCustomer_Inputs('190409')</id>
+	<title type="text" />
+	<updated>2016-03-09T09:31:28Z</updated>
+	<author>
+		<name />
+	</author>
+	<link rel="self" title="verCustomer_Input_validate" href="verCustomer_Inputs('190409')/validate">
+		<m:inline>
+			<entry>
+				<id>http://localhost:9089/t24interactiontests-iris/t24interactiontests.svc/GB0010001/Errors('190409')</id>
+				<title type="text" />
+				<updated>2016-03-09T09:31:28Z</updated>
+				<author>
+					<name />
+				</author>
+				<link rel="self" title="ProcessErrors" href="http://localhost:9089/t24interactiontests-iris/t24interactiontests.svc/errors" />
+			</entry>
+		</m:inline>	
+	</link>
+	<category term="t24interactiontests-modelsModel.verCustomer_Input" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+	<content type="application/xml">
+		<m:properties>
+			<d:CustomerCode>190409</d:CustomerCode>			
+		</m:properties>
+	</content>
+</entry>


### PR DESCRIPTION
Using the atom xml payload handler in AtomLinkHandler when no content type is available in the link element.
The content type of links in an atom document in an http response is not always same as the content type in the response header.