### PR TITLE
RequestContext class made immutable

### DIFF
--- a/interaction-core/src/main/java/com/temenos/interaction/core/rim/HTTPHypermediaRIM.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/rim/HTTPHypermediaRIM.java
@@ -81,6 +81,7 @@ import com.temenos.interaction.core.hypermedia.validation.HypermediaValidator;
 import com.temenos.interaction.core.hypermedia.validation.LogicalConfigurationListener;
 import com.temenos.interaction.core.resource.EntityResource;
 import com.temenos.interaction.core.resource.RESTResource;
+import com.temenos.interaction.core.web.RequestContext;
 
 /**
  * <P>
@@ -599,10 +600,16 @@ public class HTTPHypermediaRIM implements HTTPResourceInteractionModel {
         // work around an issue in wink, wink does not decode query parameters
         // in 1.1.3
         decodeQueryParams(queryParameters);
-
+        
         // create the interaction context
         InteractionContext ctx = new InteractionContext(uriInfo, headers, pathParameters, queryParameters,
                 currentState, metadata);
+        
+        // set the verbosity of the request as an attribute
+        if(RequestContext.getRequestContext() != null)
+            if(RequestContext.getRequestContext().getVerbosityHeader() != null)
+                ctx.setAttribute(RequestContext.VERBOSITY_HEADER, RequestContext.getRequestContext().getVerbosityHeader());
+
         return ctx;
     }
     

--- a/interaction-core/src/main/java/com/temenos/interaction/core/rim/HTTPHypermediaRIM.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/rim/HTTPHypermediaRIM.java
@@ -81,7 +81,6 @@ import com.temenos.interaction.core.hypermedia.validation.HypermediaValidator;
 import com.temenos.interaction.core.hypermedia.validation.LogicalConfigurationListener;
 import com.temenos.interaction.core.resource.EntityResource;
 import com.temenos.interaction.core.resource.RESTResource;
-import com.temenos.interaction.core.web.RequestContext;
 
 /**
  * <P>
@@ -600,16 +599,10 @@ public class HTTPHypermediaRIM implements HTTPResourceInteractionModel {
         // work around an issue in wink, wink does not decode query parameters
         // in 1.1.3
         decodeQueryParams(queryParameters);
-        
+
         // create the interaction context
         InteractionContext ctx = new InteractionContext(uriInfo, headers, pathParameters, queryParameters,
                 currentState, metadata);
-        
-        // set the verbosity of the request as an attribute
-        if(RequestContext.getRequestContext() != null)
-            if(RequestContext.getRequestContext().getVerbosityHeader() != null)
-                ctx.setAttribute(RequestContext.VERBOSITY_HEADER, RequestContext.getRequestContext().getVerbosityHeader());
-
         return ctx;
     }
     

--- a/interaction-core/src/main/java/com/temenos/interaction/core/web/RequestContext.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/web/RequestContext.java
@@ -37,7 +37,9 @@ package com.temenos.interaction.core.web;
 
 
 import java.security.Principal;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -67,7 +69,7 @@ public final class RequestContext {
     private final String requestUri;
     private final String verbosityHeader;
     private final Principal userPrincipal;
-    private final Map<String, String> headers = new HashMap<String, String>();
+    private final Map<String, List<String>> headers = new HashMap<>();
 
     public RequestContext(String basePath, String requestUri, String verbosityHeader) {
         this.basePath = basePath;
@@ -83,7 +85,7 @@ public final class RequestContext {
         this.userPrincipal = userPrincipal;
     }
 
-    public RequestContext(String basePath, String requestUri, String verbosityHeader, Map<String, String> headers) {
+    public RequestContext(String basePath, String requestUri, String verbosityHeader, Map<String, List<String>> headers) {
         this.basePath = basePath;
         this.requestUri = requestUri;
         this.verbosityHeader = verbosityHeader;
@@ -91,7 +93,7 @@ public final class RequestContext {
         this.headers.putAll(headers);
     }
     
-    public RequestContext(String basePath, String requestUri, String verbosityHeader, Principal userPrincipal, Map<String, String> headers) {
+    public RequestContext(String basePath, String requestUri, String verbosityHeader, Principal userPrincipal, Map<String, List<String>> headers) {
         this.basePath = basePath;
         this.requestUri = requestUri;
         this.verbosityHeader = verbosityHeader;
@@ -115,8 +117,16 @@ public final class RequestContext {
     	return this.userPrincipal;
     }
 
-    public String get(String name) {
-        return headers.get(name);
+    public List<String> getHeaders(String headerName) {
+        if (headers.containsKey(headerName)) {
+            return Collections.unmodifiableList(headers.get(headerName));
+        } else {
+            return Collections.emptyList();
+        }
     }
 
+    public String getFirstHeader(String headerName) {
+        List<String> headerValues = getHeaders(headerName);
+        return headerValues.isEmpty() ? null : headerValues.get(0);
+    }
 }

--- a/interaction-core/src/main/java/com/temenos/interaction/core/web/RequestContext.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/web/RequestContext.java
@@ -42,9 +42,9 @@ import java.security.Principal;
  * @author Mattias Hellborg Arthursson
  * @author Kalle Stenflo
  */
-public class RequestContext {
+public final class RequestContext {
 
-    public static final String HATEOAS_OPTIONS_HEADER = "x-jax-rs-hateoas-options";
+    public static final String VERBOSITY_HEADER = "x-jax-rs-hateoas-options";
 
     private final static ThreadLocal<RequestContext> currentContext = new ThreadLocal<RequestContext>();
 
@@ -64,12 +64,13 @@ public class RequestContext {
     private final String basePath;
     private final String requestUri;
     private final String verbosityHeader;
-    private Principal userPrincipal;
+    private final Principal userPrincipal;
 
     public RequestContext(String basePath, String requestUri, String verbosityHeader) {
         this.basePath = basePath;
         this.requestUri = requestUri;
         this.verbosityHeader = verbosityHeader;
+        this.userPrincipal = null;
     }
 
     public RequestContext(String basePath, String requestUri, String verbosityHeader, Principal userPrincipal) {

--- a/interaction-core/src/main/java/com/temenos/interaction/core/web/RequestContext.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/web/RequestContext.java
@@ -37,6 +37,8 @@ package com.temenos.interaction.core.web;
 
 
 import java.security.Principal;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author Mattias Hellborg Arthursson
@@ -44,8 +46,8 @@ import java.security.Principal;
  */
 public final class RequestContext {
 
-    public static final String VERBOSITY_HEADER = "x-jax-rs-hateoas-options";
-
+    public static final String HATEOAS_OPTIONS_HEADER = "x-jax-rs-hateoas-options";
+    
     private final static ThreadLocal<RequestContext> currentContext = new ThreadLocal<RequestContext>();
 
     public static void setRequestContext(RequestContext context) {
@@ -65,6 +67,7 @@ public final class RequestContext {
     private final String requestUri;
     private final String verbosityHeader;
     private final Principal userPrincipal;
+    private final Map<String, String> headers = new HashMap<String, String>();
 
     public RequestContext(String basePath, String requestUri, String verbosityHeader) {
         this.basePath = basePath;
@@ -79,7 +82,23 @@ public final class RequestContext {
         this.verbosityHeader = verbosityHeader;
         this.userPrincipal = userPrincipal;
     }
+
+    public RequestContext(String basePath, String requestUri, String verbosityHeader, Map<String, String> headers) {
+        this.basePath = basePath;
+        this.requestUri = requestUri;
+        this.verbosityHeader = verbosityHeader;
+        this.userPrincipal = null;
+        this.headers.putAll(headers);
+    }
     
+    public RequestContext(String basePath, String requestUri, String verbosityHeader, Principal userPrincipal, Map<String, String> headers) {
+        this.basePath = basePath;
+        this.requestUri = requestUri;
+        this.verbosityHeader = verbosityHeader;
+        this.userPrincipal = userPrincipal;
+        this.headers.putAll(headers);
+    }
+
     public String getBasePath() {
         return basePath;
     }
@@ -95,5 +114,9 @@ public final class RequestContext {
     public Principal getUserPrincipal(){
     	return this.userPrincipal;
     }
-    
+
+    public String get(String name) {
+        return headers.get(name);
+    }
+
 }

--- a/interaction-core/src/main/java/com/temenos/interaction/core/web/RequestContextFilter.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/web/RequestContextFilter.java
@@ -38,8 +38,10 @@ package com.temenos.interaction.core.web;
 
 import java.io.IOException;
 import java.security.Principal;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.servlet.Filter;
@@ -62,20 +64,19 @@ public class RequestContextFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response,
                          FilterChain chain) throws IOException, ServletException {
 
-
         final HttpServletRequest servletRequest = (HttpServletRequest) request;
-
 
         String requestURI = servletRequest.getRequestURI();
         requestURI = StringUtils.removeStart(requestURI, servletRequest.getContextPath() + servletRequest.getServletPath());
         String baseURL = StringUtils.removeEnd(servletRequest.getRequestURL().toString(), requestURI);
 
-        Map<String, String> headersMap = new HashMap<>();
-        Enumeration<String> headers = servletRequest.getHeaderNames();
-        if(headers != null) {
-            while(headers.hasMoreElements()) {
-                String header = headers.nextElement();
-                headersMap.put(header, servletRequest.getHeader(header));
+        Map<String, List<String>> headersMap = new HashMap<>();
+        Enumeration<String> headerNames = servletRequest.getHeaderNames();
+        if(headerNames != null) {
+            while(headerNames.hasMoreElements()) {
+                String headerName = headerNames.nextElement();
+                List<String> valuesList = Collections.list(servletRequest.getHeaders(headerName));
+                headersMap.put(headerName, valuesList);
             }
         }
 
@@ -88,6 +89,7 @@ public class RequestContextFilter implements Filter {
         }
 
         RequestContext.setRequestContext(ctx);
+        
         try {
             chain.doFilter(request, response);
         } finally {

--- a/interaction-core/src/main/java/com/temenos/interaction/core/web/RequestContextFilter.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/web/RequestContextFilter.java
@@ -38,6 +38,9 @@ package com.temenos.interaction.core.web;
 
 import java.io.IOException;
 import java.security.Principal;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -67,14 +70,23 @@ public class RequestContextFilter implements Filter {
         requestURI = StringUtils.removeStart(requestURI, servletRequest.getContextPath() + servletRequest.getServletPath());
         String baseURL = StringUtils.removeEnd(servletRequest.getRequestURL().toString(), requestURI);
 
+        Map<String, String> headersMap = new HashMap<>();
+        Enumeration<String> headers = servletRequest.getHeaderNames();
+        if(headers != null) {
+            while(headers.hasMoreElements()) {
+                String header = headers.nextElement();
+                headersMap.put(header, servletRequest.getHeader(header));
+            }
+        }
+
         RequestContext ctx;
         Principal userPrincipal = servletRequest.getUserPrincipal();
         if (userPrincipal != null) {
-        	ctx = new RequestContext(baseURL, servletRequest.getRequestURI(), servletRequest.getHeader(RequestContext.VERBOSITY_HEADER), userPrincipal);
+        	ctx = new RequestContext(baseURL, servletRequest.getRequestURI(), servletRequest.getHeader(RequestContext.HATEOAS_OPTIONS_HEADER), userPrincipal, headersMap);
         } else {
-        	ctx = new RequestContext(baseURL, servletRequest.getRequestURI(), servletRequest.getHeader(RequestContext.VERBOSITY_HEADER));
+        	ctx = new RequestContext(baseURL, servletRequest.getRequestURI(), servletRequest.getHeader(RequestContext.HATEOAS_OPTIONS_HEADER), headersMap);
         }
-        	
+
         RequestContext.setRequestContext(ctx);
         try {
             chain.doFilter(request, response);

--- a/interaction-core/src/main/java/com/temenos/interaction/core/web/RequestContextFilter.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/web/RequestContextFilter.java
@@ -70,9 +70,9 @@ public class RequestContextFilter implements Filter {
         RequestContext ctx;
         Principal userPrincipal = servletRequest.getUserPrincipal();
         if (userPrincipal != null) {
-        	ctx = new RequestContext(baseURL, servletRequest.getRequestURI(), servletRequest.getHeader(RequestContext.HATEOAS_OPTIONS_HEADER), userPrincipal);
+        	ctx = new RequestContext(baseURL, servletRequest.getRequestURI(), servletRequest.getHeader(RequestContext.VERBOSITY_HEADER), userPrincipal);
         } else {
-        	ctx = new RequestContext(baseURL, servletRequest.getRequestURI(), servletRequest.getHeader(RequestContext.HATEOAS_OPTIONS_HEADER));
+        	ctx = new RequestContext(baseURL, servletRequest.getRequestURI(), servletRequest.getHeader(RequestContext.VERBOSITY_HEADER));
         }
         	
         RequestContext.setRequestContext(ctx);

--- a/interaction-core/src/test/java/com/temenos/interaction/core/web/TestRequestContext.java
+++ b/interaction-core/src/test/java/com/temenos/interaction/core/web/TestRequestContext.java
@@ -1,0 +1,81 @@
+package com.temenos.interaction.core.web;
+
+/*
+ * #%L
+ * interaction-core
+ * %%
+ * Copyright (C) 2012 - 2013 Temenos Holdings N.V.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class TestRequestContext {
+
+    @Test
+    public void testInexistentHeader() {
+         Map<String, List<String>> headers = new HashMap<>();
+         List<String> singleElementList = new ArrayList<>();
+         singleElementList.add("value0");
+         headers.put("header0", singleElementList);
+         
+         RequestContext ctx = new RequestContext("\basepath", "\requesturi", null, headers);
+         
+         assertTrue(ctx.getHeaders("header1").isEmpty());
+         assertNull(ctx.getFirstHeader("header1"));
+    }
+
+	@Test
+	public void testSingleValueHeader() {
+	     Map<String, List<String>> headers = new HashMap<>();
+	     List<String> singleElementList = new ArrayList<>();
+	     singleElementList.add("value0");
+	     headers.put("header0", singleElementList);
+	     
+	     RequestContext ctx = new RequestContext("\basepath", "\requesturi", null, headers);
+	     
+	     assertEquals(1, ctx.getHeaders("header0").size());
+	     assertEquals("value0", ctx.getHeaders("header0").get(0));
+	     assertEquals("value0", ctx.getFirstHeader("header0"));
+	}
+	
+    @Test
+    public void testMultiValueHeader() {
+        Map<String, List<String>> headers = new HashMap<>();
+        List<String> list = new ArrayList<>();
+        list.add("value0");
+        list.add("value1");
+        list.add("value2");
+        headers.put("header0", list);
+
+        RequestContext ctx = new RequestContext("\basepath", "\requesturi", null, headers);
+
+        assertEquals(3, ctx.getHeaders("header0").size());
+        assertEquals("value0", ctx.getHeaders("header0").get(0));
+        assertEquals("value1", ctx.getHeaders("header0").get(1));
+        assertEquals("value2", ctx.getHeaders("header0").get(2));
+        assertEquals("value0", ctx.getFirstHeader("header0"));
+    }
+}


### PR DESCRIPTION
The parameter is set in the InteractionContext as an attribute since the header "x-jax-rs-hateoas-options" is not a standard http header.