### PR TITLE
1842917 Set Content-Length response header

### DIFF
--- a/interaction-media-odata-xml/pom.xml
+++ b/interaction-media-odata-xml/pom.xml
@@ -89,9 +89,21 @@
 			<scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 		<dependency>
 			<groupId>org.powermock</groupId>

--- a/interaction-media-odata-xml/src/main/java/com/temenos/interaction/media/odata/xml/atom/AtomXMLProvider.java
+++ b/interaction-media-odata-xml/src/main/java/com/temenos/interaction/media/odata/xml/atom/AtomXMLProvider.java
@@ -262,11 +262,13 @@ public class AtomXMLProvider implements MessageBodyReader<RESTResource>, Message
             LOGGER.error("Accepted object for writing in isWriteable, but type not supported in writeTo method");
             throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
         }
-        IOUtils.copy(new ByteArrayInputStream(buffer.toByteArray()), entityStream);
+        
         //Set response headers
-		if(httpHeaders != null) {
-			httpHeaders.putSingle(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_ATOM_XML);		//Workaround for https://issues.apache.org/jira/browse/WINK-374
-		}
+        if(httpHeaders != null) {
+            httpHeaders.putSingle(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_ATOM_XML);        //Workaround for https://issues.apache.org/jira/browse/WINK-374
+            httpHeaders.putSingle(HttpHeaders.CONTENT_LENGTH, Integer.toString(buffer.size()));
+        }
+        IOUtils.copy(new ByteArrayInputStream(buffer.toByteArray()), entityStream);
 	}
 	
 	public RESTResource processLinks(RESTResource restResource) {

--- a/interaction-media-odata-xml/src/test/java/com/temenos/interaction/media/odata/xml/atom/TestAtomXMLProvider.java
+++ b/interaction-media-odata-xml/src/test/java/com/temenos/interaction/media/odata/xml/atom/TestAtomXMLProvider.java
@@ -23,9 +23,11 @@ package com.temenos.interaction.media.odata.xml.atom;
 
 
 
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -64,10 +66,6 @@ import javax.ws.rs.core.Request;
 import javax.ws.rs.core.UriInfo;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Unmarshaller;
-
-import com.temenos.interaction.core.hypermedia.LinkGenerator;
-import com.temenos.interaction.core.hypermedia.LinkGeneratorImpl;
-import com.temenos.interaction.core.hypermedia.MethodNotAllowedException;
 
 import org.custommonkey.xmlunit.Diff;
 import org.custommonkey.xmlunit.DifferenceListener;
@@ -112,6 +110,9 @@ import com.temenos.interaction.core.hypermedia.Action;
 import com.temenos.interaction.core.hypermedia.CollectionResourceState;
 import com.temenos.interaction.core.hypermedia.EntityTransformer;
 import com.temenos.interaction.core.hypermedia.Link;
+import com.temenos.interaction.core.hypermedia.LinkGenerator;
+import com.temenos.interaction.core.hypermedia.LinkGeneratorImpl;
+import com.temenos.interaction.core.hypermedia.MethodNotAllowedException;
 import com.temenos.interaction.core.hypermedia.ResourceState;
 import com.temenos.interaction.core.hypermedia.ResourceStateMachine;
 import com.temenos.interaction.core.hypermedia.Transformer;
@@ -1515,6 +1516,9 @@ public class TestAtomXMLProvider {
 
 		//Make sure the response is atom+xml
 		assertEquals(MediaType.APPLICATION_ATOM_XML, httpHeaders.getFirst(HttpHeaders.CONTENT_TYPE));
+		
+		//content length must be greater than zero
+		assertThat(Integer.parseInt((String)httpHeaders.getFirst(HttpHeaders.CONTENT_LENGTH)), greaterThan(0));
 	}
 		
 	@Test


### PR DESCRIPTION
Set the Content-Length response header in AtomXMLProvider to the size of
the generated document.