### PR TITLE
1859482 evaluate auto-transitions after failure

### DIFF
--- a/interaction-core/src/main/java/com/temenos/interaction/core/rim/HTTPHypermediaRIM.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/rim/HTTPHypermediaRIM.java
@@ -785,9 +785,7 @@ public class HTTPHypermediaRIM implements HTTPResourceInteractionModel {
                 LOGGER.warn("Resource state [{}] has multiple auto-transitions. Using [{}].", currentState.getName(), autoTransition.getId());
             autoResponse = getResource(headers, autoTransition, ctx);
             autoTransitions = getTransitions(ctx, autoResponse.getResolvedState(), Transition.AUTO);
-        }while(!autoTransitions.isEmpty() 
-            && autoTransition.isType(Transition.AUTO) 
-            && autoResponse.getResponse().getStatus() == Status.OK.getStatusCode());
+        }while(!autoTransitions.isEmpty() && autoTransition.isType(Transition.AUTO));
         if (autoResponse.getResponse().getStatus() != Status.OK.getStatusCode()) {
             LOGGER.warn("Auto transition target did not return HttpStatus.OK status [{}]", autoResponse.getResponse().getStatus());
             responseBuilder.status(autoResponse.getResponse().getStatus());


### PR DESCRIPTION
This commit alters the behaviour of HTTPHypermediaRIM to continue evaluating autotransitions
in a failure scenario when further autotransitions are possible.