### PR TITLE
1854765 literal transition properties take precedence

### DIFF
--- a/interaction-core/src/main/java/com/temenos/interaction/core/hypermedia/LinkGeneratorImpl.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/hypermedia/LinkGeneratorImpl.java
@@ -31,6 +31,7 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriBuilderException;
 
+import org.apache.wink.common.internal.MultivaluedMapImpl;
 import org.odata4j.core.OEntity;
 import org.odata4j.format.xml.XmlFormatWriter;
 import org.slf4j.Logger;
@@ -88,6 +89,7 @@ public class LinkGeneratorImpl implements LinkGenerator {
     private Link createLink(LinkProperties linkProperties, MultivaluedMap<String, String> queryParameters, Object entity) {
         assert (RequestContext.getRequestContext() != null);
         ResourceStateProvider resourceStateProvider = resourceStateMachine.getResourceStateProvider();
+        
         try {
             ResourceState targetState = transition.getTarget();            
 
@@ -105,17 +107,6 @@ public class LinkGeneratorImpl implements LinkGenerator {
             setErrorState(targetState, resourceStateProvider);
 
             UriBuilder linkTemplate = UriBuilder.fromUri(RequestContext.getRequestContext().getBasePath());
-
-            // Add any query parameters set by the command to the response
-            if (interactionContext != null) {
-                MultivaluedMap<String, String> outQueryParams = interactionContext.getOutQueryParameters();
-
-                for (Map.Entry<String, List<String>> param : outQueryParams.entrySet()) {
-                    for(String paramValue: param.getValue()) {
-                        linkTemplate.queryParam(param.getKey(), paramValue);
-                    }
-                }
-            }
 
             if (targetState instanceof DynamicResourceState) {
                 return createLinkForDynamicResource(linkTemplate, linkProperties, targetState, entity);
@@ -166,15 +157,35 @@ public class LinkGeneratorImpl implements LinkGenerator {
         // Pass uri parameters as query parameters if they are not
         // replaceable in the path, and replace any token.
         Map<String, String> uriParameters = transition.getCommand().getUriParameters();
+        MultivaluedMap<String, String> outQueryParams = new MultivaluedMapImpl<String, String>();
+        if (interactionContext != null) {
+            MultivaluedMap<String, String> outQueryParamsTemp = interactionContext.getOutQueryParameters();
+            for (Map.Entry<String, List<String>> param : outQueryParamsTemp.entrySet()) {
+                for(String paramValue: param.getValue()) {
+                    outQueryParams.add(param.getKey(), paramValue);
+                }
+            }
+        }
+        
         if (uriParameters != null) {
             for (String key : uriParameters.keySet()) {
                 String value = uriParameters.get(key);
                 if (!targetResourcePath.contains("{" + key + "}")) {
                     String paramValue = HypermediaTemplateHelper.templateReplace(value, transitionProperties);
                     if (paramValue != null) {
-                        linkTemplate.queryParam(key, paramValue);
+                        if(outQueryParams.containsKey(key)){
+                            outQueryParams.putSingle(key, paramValue);
+                        } else {
+                            outQueryParams.add(key, paramValue);
+                        }
                     }
                 }
+            }
+        }
+        
+        for (Map.Entry<String, List<String>> param : outQueryParams.entrySet()) {
+            for(String paramValue: param.getValue()) {
+                linkTemplate.queryParam(param.getKey(), paramValue);
             }
         }
     }

--- a/interaction-core/src/main/java/com/temenos/interaction/core/hypermedia/LinkGeneratorImpl.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/hypermedia/LinkGeneratorImpl.java
@@ -173,11 +173,7 @@ public class LinkGeneratorImpl implements LinkGenerator {
                 if (!targetResourcePath.contains("{" + key + "}")) {
                     String paramValue = HypermediaTemplateHelper.templateReplace(value, transitionProperties);
                     if (paramValue != null) {
-                        if(outQueryParams.containsKey(key)){
-                            outQueryParams.putSingle(key, paramValue);
-                        } else {
-                            outQueryParams.add(key, paramValue);
-                        }
+                        outQueryParams.putSingle(key, paramValue);
                     }
                 }
             }

--- a/interaction-core/src/test/java/com/temenos/interaction/core/hypermedia/TestLinkGeneratorImpl.java
+++ b/interaction-core/src/test/java/com/temenos/interaction/core/hypermedia/TestLinkGeneratorImpl.java
@@ -53,6 +53,7 @@ import org.odata4j.edm.EdmComplexType;
 import org.odata4j.edm.EdmEntitySet;
 
 import com.temenos.interaction.core.MultivaluedMapImpl;
+import com.temenos.interaction.core.command.InteractionContext;
 import com.temenos.interaction.core.web.RequestContext;
 
 
@@ -132,19 +133,57 @@ public class TestLinkGeneratorImpl {
     }
     
     @Test
-    public void testCreateLinkHrefUriParameterEmptyTokensReplaceQueryParameters() {
+    public void testCreateLinkHrefUriParameterTransitionPropertiesReplaceQueryParameters() {
         ResourceStateMachine engine = new ResourceStateMachine(mock(ResourceState.class), new BeanTransformer());
         Map<String, String> uriParameters = new HashMap<String, String>();
-        uriParameters.put("param1", "");
+        uriParameters.put("param1", "delta");
         Transition t = new Transition.Builder().source(mock(ResourceState.class)).target(mockTarget("/test")).uriParameters(uriParameters).build();
+        InteractionContext ctx = mock(InteractionContext.class);
         MultivaluedMap<String, String> queryParameters = new MultivaluedMapImpl<String>();
-        queryParameters.add("$param", "123");
-        LinkGenerator linkGenerator = new LinkGeneratorImpl(engine, t, null);
-        Collection<Link> links = linkGenerator.createLink(null, queryParameters, null);
+        queryParameters.add("param1", "alpha");
+        queryParameters.add("param2", "beta");
+        queryParameters.add("param3", "gamma");
+        when(ctx.getOutQueryParameters()).thenReturn(queryParameters);
+        LinkGenerator linkGenerator = new LinkGeneratorImpl(engine, t, ctx);
+        Collection<Link> links = linkGenerator.createLink(null, null, null);
         assertFalse(links.isEmpty());
-        assertEquals("/baseuri/test?param1=", links.iterator().next().getHref());
+        assertEquals("/baseuri/test?param1=delta&param2=beta&param3=gamma", links.iterator().next().getHref());
     }
-
+    
+    @Test
+    public void testCreateLinkHrefUriParametersQueryParametersAndNoTransitionProperties() {
+        ResourceStateMachine engine = new ResourceStateMachine(mock(ResourceState.class), new BeanTransformer());
+        Map<String, String> uriParameters = new HashMap<String, String>();
+        Transition t = new Transition.Builder().source(mock(ResourceState.class)).target(mockTarget("/test")).uriParameters(uriParameters).build();
+        InteractionContext ctx = mock(InteractionContext.class);
+        MultivaluedMap<String, String> queryParameters = new MultivaluedMapImpl<String>();
+        queryParameters.add("param1", "alpha");
+        queryParameters.add("param2", "beta");
+        queryParameters.add("param3", "gamma");
+        when(ctx.getOutQueryParameters()).thenReturn(queryParameters);
+        LinkGenerator linkGenerator = new LinkGeneratorImpl(engine, t, ctx);
+        Collection<Link> links = linkGenerator.createLink(null, null, null);
+        assertFalse(links.isEmpty());
+        assertEquals("/baseuri/test?param1=alpha&param2=beta&param3=gamma", links.iterator().next().getHref());
+    }
+    
+    @Test
+    public void testCreateLinkHrefUriParametersTransitionPropertiesAndNoQueryParameters() {
+        ResourceStateMachine engine = new ResourceStateMachine(mock(ResourceState.class), new BeanTransformer());
+        Map<String, String> uriParameters = new HashMap<String, String>();
+        uriParameters.put("param1", "alpha");
+        uriParameters.put("param2", "beta");
+        uriParameters.put("param3", "gamma");
+        Transition t = new Transition.Builder().source(mock(ResourceState.class)).target(mockTarget("/test")).uriParameters(uriParameters).build();
+        InteractionContext ctx = mock(InteractionContext.class);
+        MultivaluedMap<String, String> queryParameters = new MultivaluedMapImpl<String>();
+        when(ctx.getOutQueryParameters()).thenReturn(queryParameters);
+        LinkGenerator linkGenerator = new LinkGeneratorImpl(engine, t, ctx);
+        Collection<Link> links = linkGenerator.createLink(null, null, null);
+        assertFalse(links.isEmpty());
+        assertEquals("/baseuri/test?param1=alpha&param2=beta&param3=gamma", links.iterator().next().getHref());
+    }
+    
     @Test
     public void testCreateLinkHrefAllQueryParameters() {
         ResourceStateMachine engine = new ResourceStateMachine(mock(ResourceState.class), new BeanTransformer());

--- a/interaction-core/src/test/java/com/temenos/interaction/core/hypermedia/TestLinkGeneratorImpl.java
+++ b/interaction-core/src/test/java/com/temenos/interaction/core/hypermedia/TestLinkGeneratorImpl.java
@@ -130,6 +130,20 @@ public class TestLinkGeneratorImpl {
         assertFalse(links.isEmpty());
         assertEquals("/baseuri/test?filter=123", links.iterator().next().getHref());
     }
+    
+    @Test
+    public void testCreateLinkHrefUriParameterEmptyTokensReplaceQueryParameters() {
+        ResourceStateMachine engine = new ResourceStateMachine(mock(ResourceState.class), new BeanTransformer());
+        Map<String, String> uriParameters = new HashMap<String, String>();
+        uriParameters.put("param1", "");
+        Transition t = new Transition.Builder().source(mock(ResourceState.class)).target(mockTarget("/test")).uriParameters(uriParameters).build();
+        MultivaluedMap<String, String> queryParameters = new MultivaluedMapImpl<String>();
+        queryParameters.add("$param", "123");
+        LinkGenerator linkGenerator = new LinkGeneratorImpl(engine, t, null);
+        Collection<Link> links = linkGenerator.createLink(null, queryParameters, null);
+        assertFalse(links.isEmpty());
+        assertEquals("/baseuri/test?param1=", links.iterator().next().getHref());
+    }
 
     @Test
     public void testCreateLinkHrefAllQueryParameters() {


### PR DESCRIPTION
- Given: A RIM for a resource with three transition properties A, B and C
- When: The resource is requested
- Then: Literal transition properties declared in the RIM must overwrite identically named request query parameters when links' href attributes are built