### PR TITLE
1883279 - Swagger Refactor

### DIFF
--- a/interaction-dsl/com.temenos.interaction.rimdsl.generator/pom.xml
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.generator/pom.xml
@@ -184,6 +184,12 @@
             <artifactId>com.temenos.interaction.rimdsl</artifactId>
             <version>${project.version}</version>
         </dependency>
+        
+         <dependency>
+            <groupId>com.temenos.interaction</groupId>
+            <artifactId>interaction-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
         	<groupId>org.eclipse.xtext</groupId>

--- a/interaction-dsl/com.temenos.interaction.rimdsl.generator/src/main/java/com/temenos/interaction/rimdsl/generator/launcher/Generator.java
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.generator/src/main/java/com/temenos/interaction/rimdsl/generator/launcher/Generator.java
@@ -145,41 +145,26 @@ public class Generator {
 		resourceSet.addLoadOption(XtextResource.OPTION_RESOLVE_ALL, Boolean.TRUE);
 		Resource resource = resourceSet.getResource(URI.createFileURI(inputPath), true);
         
-		if(metadata!=null) {
-		    
-		    Map<String, Object> entitiesMap = new HashMap<String, Object>();
-		    
-		    for(State key : Iterables.<State>filter(IteratorExtensions.<EObject>toIterable(resource.getAllContents()), State.class)) {
-		        
-                String entity = key.getEntity().getName();
-                
-                if (StringUtils.isNotEmpty(entity)) {
-                
-                    try {
-                        
-                        EntityMetadata em = metadata.getEntityMetadata(entity);
-                        
-                        if (null != em) {
-                            
-                            Map<String, Object> entityPropMap = new HashMap<String, Object>();
-                            
-                            // To refactor
-                            
-                            for (String propertySimple : em.getTopLevelProperties()) {
-                                
+		if(metadata!=null) {		    
+		    Map<String, Object> entitiesMap = new HashMap<String, Object>();		    
+		    for(State key : Iterables.<State>filter(IteratorExtensions.<EObject>toIterable(resource.getAllContents()), State.class)) {		        
+                String entity = key.getEntity().getName();                
+                if (StringUtils.isNotEmpty(entity)) {                
+                    try {                        
+                        EntityMetadata em = metadata.getEntityMetadata(entity);                        
+                        if (null != em) {                            
+                            Map<String, Object> entityPropMap = new HashMap<String, Object>();                            
+                            for (String propertySimple : em.getTopLevelProperties()) {                                
                                 if(!em.isPropertyList(propertySimple)) {
                                     String propertyName = em.getSimplePropertyName(propertySimple);
                                     entityPropMap.put(propertyName, "string");
-                                } else {
-                                    
+                                } else {                                    
                                     String propertyName = em.getSimplePropertyName(propertySimple);
                                     entityPropMap.put(propertyName, complexTypeHandler(propertySimple, em));
                                 }
-                            }
-                            
+                            }                            
                             entitiesMap.put(entity, entityPropMap);
-                        }
-                        
+                        }                        
                     } catch (Exception e) {
                         System.out.println("Entity Not found: " + entity);
                     }

--- a/interaction-dsl/com.temenos.interaction.rimdsl.generator/src/main/java/com/temenos/interaction/rimdsl/generator/launcher/Generator.java
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.generator/src/main/java/com/temenos/interaction/rimdsl/generator/launcher/Generator.java
@@ -25,9 +25,15 @@ package com.temenos.interaction.rimdsl.generator.launcher;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import org.apache.commons.lang.StringUtils;
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xtext.generator.IGenerator;
 import org.eclipse.xtext.generator.JavaIoFileSystemAccess;
@@ -37,8 +43,13 @@ import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.validation.CheckMode;
 import org.eclipse.xtext.validation.IResourceValidator;
 import org.eclipse.xtext.validation.Issue;
+import org.eclipse.xtext.xbase.lib.IteratorExtensions;
 
+import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
+import com.temenos.interaction.core.entity.EntityMetadata;
+import com.temenos.interaction.core.entity.Metadata;
+import com.temenos.interaction.rimdsl.rim.State;
 
 /**
  * This class generates code from a DSL model.
@@ -77,6 +88,21 @@ public class Generator {
 		return result;
 	}
 	
+	public boolean runGeneratorDir(String inputDirPath, Metadata metadata, String outputPath) {
+        List<String> files = getFiles(inputDirPath, ".rim");
+        for (String modelPath : files) {
+            resourceSet.getResources().add(resourceSet.getResource(URI.createFileURI(modelPath), true));
+        }
+        boolean result = true;
+        for (String modelPath : files) {
+            boolean fileResult = runGenerator(modelPath, metadata, outputPath);
+            if (!fileResult) {
+                result = fileResult;
+            }
+        }
+        return result;
+    }
+	
 	protected String toSystemFileName(String fileName) {
 		return fileName.replace("/", File.separator);
 	}
@@ -110,10 +136,57 @@ public class Generator {
 	}
 	
 	public boolean runGenerator(String inputPath, String outputPath) {
+	    return runGenerator(inputPath, null, outputPath);
+	}
+	
+	public boolean runGenerator(String inputPath, Metadata metadata, String outputPath) {
 		
 		// load the resource
 		resourceSet.addLoadOption(XtextResource.OPTION_RESOLVE_ALL, Boolean.TRUE);
 		Resource resource = resourceSet.getResource(URI.createFileURI(inputPath), true);
+        
+		if(metadata!=null) {
+		    
+		    Map<String, Object> entitiesMap = new HashMap<String, Object>();
+		    
+		    for(State key : Iterables.<State>filter(IteratorExtensions.<EObject>toIterable(resource.getAllContents()), State.class)) {
+		        
+                String entity = key.getEntity().getName();
+                
+                if (StringUtils.isNotEmpty(entity)) {
+                
+                    try {
+                        
+                        EntityMetadata em = metadata.getEntityMetadata(entity);
+                        
+                        if (null != em) {
+                            
+                            Map<String, Object> entityPropMap = new HashMap<String, Object>();
+                            
+                            // To refactor
+                            
+                            for (String propertySimple : em.getTopLevelProperties()) {
+                                
+                                if(!em.isPropertyList(propertySimple)) {
+                                    String propertyName = em.getSimplePropertyName(propertySimple);
+                                    entityPropMap.put(propertyName, "string");
+                                } else {
+                                    
+                                    String propertyName = em.getSimplePropertyName(propertySimple);
+                                    entityPropMap.put(propertyName, complexTypeHandler(propertySimple, em));
+                                }
+                            }
+                            
+                            entitiesMap.put(entity, entityPropMap);
+                        }
+                        
+                    } catch (Exception e) {
+                        System.out.println("Entity Not found: " + entity);
+                    }
+                }
+		    }
+		    resource.getResourceSet().getLoadOptions().put("Metadata", entitiesMap);
+		}
 
 		// validate the resource
 		List<Issue> list = validator.validate(resource, CheckMode.ALL, CancelIndicator.NullImpl);
@@ -137,4 +210,37 @@ public class Generator {
 			this.listener = listener;
 		}
 	}	
+	
+	public Map<String, Object> complexTypeHandler(String propertyName, EntityMetadata em) {
+	    
+	    Map<String, Object> map = new HashMap<>();
+	    
+	    // 1st level
+	    
+	    for (String property : em.getPropertyVocabularyKeySet()) {
+	        
+	        if(property.startsWith(propertyName) && !property.equals(propertyName)) {
+	            
+	            if(em.isPropertyList(property)) {
+	                // Complex
+	                    
+	                Map<String,Object> subMap = complexTypeHandler(property, em);
+	                map.put(em.getSimplePropertyName(property),subMap);
+	            
+	            } else {
+	                // SIMPLE	                
+	                Pattern pattern = Pattern.compile("(?:"+propertyName+")(?:\\.)(.*)");
+	                Matcher matcher = pattern.matcher(property);
+	                while(matcher.find()) {
+	                    String propertyCapture = matcher.group(1);
+	                    if(em.getSimplePropertyName(property).equals(propertyCapture)) {
+	                        map.put(em.getSimplePropertyName(property),"string");
+	                    }
+	                }
+	            }
+	        }
+	    }
+	    
+	    return map;	    
+	}
 }

--- a/interaction-dsl/com.temenos.interaction.rimdsl.generator/src/test/java/com/temenos/interaction/rimdsl/generator/launcher/GeneratorTest.java
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.generator/src/test/java/com/temenos/interaction/rimdsl/generator/launcher/GeneratorTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 
 import com.google.inject.Injector;
 import com.temenos.interaction.core.entity.EntityMetadata;
+import com.temenos.interaction.core.entity.Metadata;
 import com.temenos.interaction.core.entity.vocabulary.Vocabulary;
 import com.temenos.interaction.core.entity.vocabulary.terms.TermComplexGroup;
 import com.temenos.interaction.core.entity.vocabulary.terms.TermComplexType;
@@ -24,6 +25,7 @@ import com.temenos.interaction.core.entity.vocabulary.terms.TermListType;
 import com.temenos.interaction.core.entity.vocabulary.terms.TermValueType;
 import com.temenos.interaction.rimdsl.RIMDslStandaloneSetup;
 import com.temenos.interaction.rimdsl.RIMDslStandaloneSetupSpringPRD;
+import com.temenos.interaction.rimdsl.RIMDslStandaloneSetupSwagger;
 
 public class GeneratorTest {
 	private File validGenJavaDir = new File("target/valid-gen-java");
@@ -178,34 +180,144 @@ public class GeneratorTest {
 		generator.runGenerator("src/test/resources/Restbucks.rim", validGenJavaDir.getPath());
 		
 		verify(listener, times(0)).notify(anyString());
-	}	
+	}
 	
+	@Test
+    public void testStandaloneSpringPRDListenerWithSimpleRimAndMetadata() {
+        Injector injector = new RIMDslStandaloneSetupSpringPRD().createInjectorAndDoEMFRegistration();
+        Generator generator = injector.getInstance(Generator.class);        
+        ValidatorEventListener listener = mock(ValidatorEventListener.class);        
+        generator.setValidatorEventListener(listener);
+        Metadata metadata = new Metadata("metadata");
+        metadata.setEntityMetadata(new EntityMetadata("Note"));     
+        generator.runGenerator("src/test/resources/Simple.rim", metadata, validGenJavaDir.getPath());        
+        verify(listener, times(0)).notify(anyString());
+    }
 	
+	@Test
+    public void testStandaloneSetupSpringPRDListenerWithRimDirAndMetadata() {
+        Injector injector = new RIMDslStandaloneSetupSpringPRD().createInjectorAndDoEMFRegistration();
+        Generator generator = injector.getInstance(Generator.class);        
+        ValidatorEventListener listener = mock(ValidatorEventListener.class);        
+        generator.setValidatorEventListener(listener);        
+        Metadata metadata = new Metadata("metadata");
+        metadata.setEntityMetadata(new EntityMetadata("Note"));     
+        generator.runGeneratorDir("src/test/resources/Simple.rim", metadata, validGenJavaDir.getPath());        
+        verify(listener, times(0)).notify(anyString());
+    }
+	
+    @Test
+    public void testStandaloneSetupSpringPRDListenerWithRimDirAndNoMetadata() {
+        Injector injector = new RIMDslStandaloneSetupSpringPRD().createInjectorAndDoEMFRegistration();
+        Generator generator = injector.getInstance(Generator.class);        
+        ValidatorEventListener listener = mock(ValidatorEventListener.class);        
+        generator.setValidatorEventListener(listener);
+        generator.runGeneratorDir("src/test/resources/Simple.rim", validGenJavaDir.getPath());        
+        verify(listener, times(0)).notify(anyString());
+    }
+	
+	@Test
+    public void testStandaloneSetupSwaggerListenerWithSimpleRimAndMetadata() {
+        Injector injector = new RIMDslStandaloneSetupSwagger().createInjectorAndDoEMFRegistration();
+        Generator generator = injector.getInstance(Generator.class);
+        ValidatorEventListener listener = mock(ValidatorEventListener.class);
+        generator.setValidatorEventListener(listener);
+        Metadata metadata = new Metadata("metadata");
+        EntityMetadata em = new EntityMetadata("Note");
+        
+        Vocabulary vocId = new Vocabulary();
+        vocId.setTerm(new TermValueType(TermValueType.TEXT));
+        em.setPropertyVocabulary("name", vocId);
+        
+        Vocabulary vocNotes = new Vocabulary();
+        vocNotes.setTerm(new TermListType(true));
+        vocNotes.setTerm(new TermComplexType(true));
+        em.setPropertyVocabulary("notes", vocNotes);        
+        
+        Vocabulary vocNoteText = new Vocabulary();
+        vocNoteText.setTerm(new TermValueType(TermValueType.TEXT));
+        vocNoteText.setTerm(new TermComplexGroup("notes"));
+        em.setPropertyVocabulary("Text", vocNoteText, Collections.enumeration(Collections.singletonList("notes")));   
+        
+        Vocabulary vocNoteNumbers = new Vocabulary();
+        vocNoteNumbers.setTerm(new TermListType(true));
+        vocNotes.setTerm(new TermComplexType(true));
+        em.setPropertyVocabulary("Numbers", vocNoteNumbers, Collections.enumeration(Collections.singletonList("notes")));
+        
+        Vocabulary vocNoteNumber = new Vocabulary();
+        vocNoteNumber.setTerm(new TermValueType(TermValueType.TEXT));
+        vocNoteNumber.setTerm(new TermComplexGroup("Numbers"));
+        em.setPropertyVocabulary("Number", vocNoteNumber, Collections.enumeration(Collections.singletonList("Numbers")));
+        
+        
+        metadata.setEntityMetadata(em);
+        generator.runGenerator("src/test/resources/Simple.rim", metadata, validGenJavaDir.getPath());
+        verify(listener, times(0)).notify(anyString());
+    }
+	
+	@Test
+    public void testStandaloneSetupSwaggerListenerWithDirAndMetadata() {
+        Injector injector = new RIMDslStandaloneSetupSwagger().createInjectorAndDoEMFRegistration();
+        Generator generator = injector.getInstance(Generator.class);
+        ValidatorEventListener listener = mock(ValidatorEventListener.class);
+        generator.setValidatorEventListener(listener);
+        Metadata metadata = new Metadata("metadata");
+        metadata.setEntityMetadata(new EntityMetadata("Note"));
+        generator.runGeneratorDir("src/test/resources/Simple.rim", metadata, validGenJavaDir.getPath());
+        verify(listener, times(0)).notify(anyString());
+    }
+	
+	@Test
+    public void testStandaloneSetupSwaggerListenerWithDirAndNoMetadata() {
+        Injector injector = new RIMDslStandaloneSetupSwagger().createInjectorAndDoEMFRegistration();
+        Generator generator = injector.getInstance(Generator.class);
+        ValidatorEventListener listener = mock(ValidatorEventListener.class);
+        generator.setValidatorEventListener(listener);
+        generator.runGeneratorDir("src/test/resources/Simple.rim", validGenJavaDir.getPath());
+        verify(listener, times(0)).notify(anyString());
+    }
+	
+	@Test
+    public void testStandaloneSetupSwaggerListenerWithInvalidRimOnDirAndNoMetadata() {
+        Injector injector = new RIMDslStandaloneSetupSwagger().createInjectorAndDoEMFRegistration();
+        Generator generator = injector.getInstance(Generator.class);
+        ValidatorEventListener listener = mock(ValidatorEventListener.class);
+        generator.setValidatorEventListener(listener);
+        generator.runGeneratorDir("src/test/resources/invalid.rim", validGenJavaDir.getPath());
+        verify(listener, times(1)).notify(anyString());
+    }
+	
+	@Test
+    public void testStandaloneSetupSwaggerListenerWithInvalidRimOnDirAndMetadata() {
+        Injector injector = new RIMDslStandaloneSetupSwagger().createInjectorAndDoEMFRegistration();
+        Generator generator = injector.getInstance(Generator.class);
+        ValidatorEventListener listener = mock(ValidatorEventListener.class);
+        Metadata metadata = new Metadata("metadata");
+        metadata.setEntityMetadata(new EntityMetadata("ENTITY"));
+        generator.setValidatorEventListener(listener);
+        generator.runGeneratorDir("src/test/resources/invalid.rim", metadata, validGenJavaDir.getPath());
+        verify(listener, times(1)).notify(anyString());
+    }
+
 	@Test
 	public void testComplexTypeHandler() {
 	    Injector injector = new RIMDslStandaloneSetupSpringPRD().createInjectorAndDoEMFRegistration();
-	    Generator generator = injector.getInstance(Generator.class);
-	    
-	    EntityMetadata em = new EntityMetadata("Riders");
-	    
+	    Generator generator = injector.getInstance(Generator.class);	    
+	    EntityMetadata em = new EntityMetadata("Riders");	    
 	    Vocabulary vocId = new Vocabulary();
 	    vocId.setTerm(new TermValueType(TermValueType.TEXT));
-	    em.setPropertyVocabulary("name", vocId);
-	    
+	    em.setPropertyVocabulary("name", vocId);	    
 	    Vocabulary vocBody = new Vocabulary();
         vocBody.setTerm(new TermValueType(TermValueType.INTEGER_NUMBER));
         em.setPropertyVocabulary("age", vocBody);
-
         Vocabulary vocRides = new Vocabulary();
         vocRides.setTerm(new TermListType(true));
         vocRides.setTerm(new TermComplexType(true));
-        em.setPropertyVocabulary("rides", vocRides);
-        
+        em.setPropertyVocabulary("rides", vocRides);        
         Vocabulary vocHorseName = new Vocabulary();
         vocHorseName.setTerm(new TermValueType(TermValueType.TEXT));
         vocHorseName.setTerm(new TermComplexGroup("rides"));
-        em.setPropertyVocabulary("HorseName", vocHorseName, Collections.enumeration(Collections.singletonList("rides")));
-        
+        em.setPropertyVocabulary("HorseName", vocHorseName, Collections.enumeration(Collections.singletonList("rides")));        
         Vocabulary vocHorseSize = new Vocabulary();
         vocHorseSize.setTerm(new TermValueType(TermValueType.TEXT));
         vocHorseSize.setTerm(new TermComplexGroup("rides"));

--- a/interaction-dsl/com.temenos.interaction.rimdsl.tests/src/Simple.rim
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.tests/src/Simple.rim
@@ -1,6 +1,6 @@
 // test comment
 domain SimpleModel {
-	rim Simple {
+	rim Simple @ Api : tags ( "Simple" ) {
 
 		event GET { method: GET }
 		event PUT { method: PUT }
@@ -12,6 +12,8 @@ domain SimpleModel {
 		command GETNotes
 		command GETNote
 		command DELETENote
+		
+		basepath: "/Simple"
 
 		initial resource notes {
 			type: collection

--- a/interaction-dsl/com.temenos.interaction.rimdsl.tests/src/api-docs-SimpleDomain-Simple.json
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.tests/src/api-docs-SimpleDomain-Simple.json
@@ -1,0 +1,88 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "",
+        "description": "",
+        "version": "1.0.0"
+    },
+    "produces": ["application/json","application/xml"],
+"paths": {
+"/B": {
+    "post": {
+        "description": "",
+        "consumes": ["application/json","application/xml"],
+        "produces": ["application/json","application/xml"],
+        "parameters": [
+            {
+                "in": "body",
+                "name": "body",
+                "description": "-",
+                "required": true,
+                "schema": {
+                    "$ref": "#/definitions/ENTITY"
+                }
+            }
+        ],
+         "tags": ["Simple"
+        ],
+            "responses": {
+            "201": {
+                "description": "Created",
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ENTITY"
+                    }
+                }
+            },
+            "400": {
+                "description": "Bad request",
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ErrorsMvGroup"
+                    }
+                }
+            },
+            "401": {
+                "description": "Authentication/Authorization error",
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ErrorsMvGroup"
+                    }
+                }
+            },
+            "404": {
+                "description": "Resource not found"
+            },
+            "default": {
+                "description": "Unexpected output",
+                "schema": {
+                    "$ref": "#/definitions/ErrorsMvGroup"
+                }
+            }
+        }
+    }
+}
+},
+"definitions": {
+    "ErrorsMvGroup": {
+        "type": "object",
+        "properties": {
+            "Text": {
+                "type": "string"
+            },
+            "Type": {
+                "type": "string"
+            },
+            "Info": {
+                "type": "string"
+            },
+            "Code": {
+                "type": "string"
+            }
+        }
+    }
+}
+}

--- a/interaction-dsl/com.temenos.interaction.rimdsl.tests/src/apiSimple.rim
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.tests/src/apiSimple.rim
@@ -1,0 +1,32 @@
+domain SimpleDomain {
+    rim Simple @ Api : tags ( "Simple" ) {
+        event POST { method: POST }
+
+        command GetEntity
+        command GetException
+        command UpdateEntity
+
+        basepath: "/Simple"
+
+        initial resource A {
+            type: collection
+            entity: ENTITY
+            view: GetEntity
+            path: "/A"
+            POST -> B
+        }
+
+        exception resource E {
+            type: collection
+            entity: EXCEPTION
+            view: GetException
+        }
+
+        resource B {
+            type: item
+            entity: ENTITY
+            actions [ UpdateEntity ]
+            path: "/B"
+        }
+    }
+}

--- a/interaction-dsl/com.temenos.interaction.rimdsl.tests/src/com/temenos/interaction/rimdsl/SwaggerGeneratorTest.java
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.tests/src/com/temenos/interaction/rimdsl/SwaggerGeneratorTest.java
@@ -97,72 +97,72 @@ public class SwaggerGeneratorTest {
 	private final static String SIMPLE_STATES_SWAGGER = "" +		
 	"{" + LINE_SEP + 
 	"    \"swagger\": \"2.0\"," + LINE_SEP + 
-	"    \"info\": {" + LINE_SEP + 
-	"        \"title\": \"\"," + LINE_SEP + 
-	"        \"description\": \"\"," + LINE_SEP + 
-	"        \"version\": \"1.0.0\"" + LINE_SEP + 
-	"    }," + LINE_SEP + 
-	"    \"produces\": [\"application/json\",\"application/xml\"]," + LINE_SEP + 
-	"\"paths\": {" + LINE_SEP +
-	"    \"/B\": {" + LINE_SEP + 
-	"        \"post\": {" + LINE_SEP + 
-	"            \"description\": \"\"," + LINE_SEP + 
-	"            \"consumes\": [\"application/json\",\"application/xml\"]," + LINE_SEP + 
-	"            \"produces\": [\"application/json\",\"application/xml\"]," + LINE_SEP + 
-	"            \"parameters\": [" + LINE_SEP + 
-	"                {" + LINE_SEP + 
-	"                    \"in\": \"body\"," + LINE_SEP + 
-	"                    \"name\": \"body\"," + LINE_SEP + 
-	"                    \"description\": \"-\"," + LINE_SEP + 
-	"                    \"required\": true," + LINE_SEP + 
-	"                    \"schema\": {" + LINE_SEP + 
-	"                        \"$ref\": \"#/definitions/ENTITY\"" + LINE_SEP + 
-	"                    }" + LINE_SEP + 
-	"                }" + LINE_SEP + 
-	"            ]," + LINE_SEP + 
-	"             \"tags\": [\"Simple\"" + LINE_SEP + 
-	"            ]," + LINE_SEP + 
-	"                \"responses\": {" + LINE_SEP + 
-	"                \"201\": {" + LINE_SEP + 
-	"                    \"description\": \"Created\"," + LINE_SEP + 
-	"                    \"schema\": {" + LINE_SEP + 
-	"                        \"type\": \"array\"," + LINE_SEP + 
-	"                        \"items\": {" + LINE_SEP + 
-	"                            \"$ref\": \"#/definitions/ENTITY\"" + LINE_SEP + 
-	"                        }" + LINE_SEP + 
-	"                    }" + LINE_SEP + 
-	"                }," + LINE_SEP + 
-	"                \"400\": {" + LINE_SEP + 
-	"                    \"description\": \"Bad request\"," + LINE_SEP + 
-	"                    \"schema\": {" + LINE_SEP + 
-	"                        \"type\": \"array\"," + LINE_SEP + 
-	"                        \"items\": {" + LINE_SEP + 
-	"                            \"$ref\": \"#/definitions/ErrorsMvGroup\"" + LINE_SEP + 
-	"                        }" + LINE_SEP + 
-	"                    }" + LINE_SEP + 
-	"                }," + LINE_SEP + 
-	"                \"401\": {" + LINE_SEP + 
-	"                    \"description\": \"Authentication/Authorization error\"," + LINE_SEP + 
-	"                    \"schema\": {" + LINE_SEP + 
-	"                        \"type\": \"array\"," + LINE_SEP + 
-	"                        \"items\": {" + LINE_SEP + 
-	"                            \"$ref\": \"#/definitions/ErrorsMvGroup\"" + LINE_SEP + 
-	"                        }" + LINE_SEP + 
-	"                    }" + LINE_SEP + 
-	"                }," + LINE_SEP + 
-	"                \"404\": {" + LINE_SEP + 
-	"                    \"description\": \"Resource not found\"" + LINE_SEP + 
-	"                }," + LINE_SEP + 
-	"                \"default\": {" + LINE_SEP + 
-	"                    \"description\": \"Unexpected output\"," + LINE_SEP + 
-	"                    \"schema\": {" + LINE_SEP + 
-	"                        \"$ref\": \"#/definitions/ErrorsMvGroup\"" + LINE_SEP + 
-	"                    }" + LINE_SEP + 
-	"                }" + LINE_SEP + 
-	"            }" + LINE_SEP + 
-	"        }" + LINE_SEP + 
-	"    }" + LINE_SEP + 
-	"}," + LINE_SEP + 
+    "    \"info\": {" + LINE_SEP + 
+    "        \"title\": \"\"," + LINE_SEP + 
+    "        \"description\": \"\"," + LINE_SEP + 
+    "        \"version\": \"1.0.0\"" + LINE_SEP + 
+    "    }," + LINE_SEP + 
+    "    \"produces\": [\"application/json\",\"application/xml\"]," + LINE_SEP + 
+    "\"paths\": {" + LINE_SEP +
+    "\"/B\": {" + LINE_SEP + 
+    "    \"post\": {" + LINE_SEP + 
+    "        \"description\": \"\"," + LINE_SEP + 
+    "        \"consumes\": [\"application/json\",\"application/xml\"]," + LINE_SEP + 
+    "        \"produces\": [\"application/json\",\"application/xml\"]," + LINE_SEP + 
+    "        \"parameters\": [" + LINE_SEP + 
+    "            {" + LINE_SEP + 
+    "                \"in\": \"body\"," + LINE_SEP + 
+    "                \"name\": \"body\"," + LINE_SEP + 
+    "                \"description\": \"-\"," + LINE_SEP + 
+    "                \"required\": true," + LINE_SEP + 
+    "                \"schema\": {" + LINE_SEP + 
+    "                    \"$ref\": \"#/definitions/ENTITY\"" + LINE_SEP + 
+    "                }" + LINE_SEP + 
+    "            }" + LINE_SEP + 
+    "        ]," + LINE_SEP + 
+    "         \"tags\": [\"Simple\"" + LINE_SEP + 
+    "        ]," + LINE_SEP + 
+    "            \"responses\": {" + LINE_SEP + 
+    "            \"201\": {" + LINE_SEP + 
+    "                \"description\": \"Created\"," + LINE_SEP + 
+    "                \"schema\": {" + LINE_SEP + 
+    "                    \"type\": \"array\"," + LINE_SEP + 
+    "                    \"items\": {" + LINE_SEP + 
+    "                        \"$ref\": \"#/definitions/ENTITY\"" + LINE_SEP + 
+    "                    }" + LINE_SEP + 
+    "                }" + LINE_SEP + 
+    "            }," + LINE_SEP + 
+    "            \"400\": {" + LINE_SEP + 
+    "                \"description\": \"Bad request\"," + LINE_SEP + 
+    "                \"schema\": {" + LINE_SEP + 
+    "                    \"type\": \"array\"," + LINE_SEP + 
+    "                    \"items\": {" + LINE_SEP + 
+    "                        \"$ref\": \"#/definitions/ErrorsMvGroup\"" + LINE_SEP + 
+    "                    }" + LINE_SEP + 
+    "                }" + LINE_SEP + 
+    "            }," + LINE_SEP + 
+    "            \"401\": {" + LINE_SEP + 
+    "                \"description\": \"Authentication/Authorization error\"," + LINE_SEP + 
+    "                \"schema\": {" + LINE_SEP + 
+    "                    \"type\": \"array\"," + LINE_SEP + 
+    "                    \"items\": {" + LINE_SEP + 
+    "                        \"$ref\": \"#/definitions/ErrorsMvGroup\"" + LINE_SEP + 
+    "                    }" + LINE_SEP + 
+    "                }" + LINE_SEP + 
+    "            }," + LINE_SEP + 
+    "            \"404\": {" + LINE_SEP + 
+    "                \"description\": \"Resource not found\"" + LINE_SEP + 
+    "            }," + LINE_SEP + 
+    "            \"default\": {" + LINE_SEP + 
+    "                \"description\": \"Unexpected output\"," + LINE_SEP + 
+    "                \"schema\": {" + LINE_SEP + 
+    "                    \"$ref\": \"#/definitions/ErrorsMvGroup\"" + LINE_SEP + 
+    "                }" + LINE_SEP + 
+    "            }" + LINE_SEP + 
+    "        }" + LINE_SEP + 
+    "    }" + LINE_SEP + 
+    "}" + LINE_SEP + 
+    "}," + LINE_SEP + 
 	"\"definitions\": {" + LINE_SEP + 
 	"    \"ErrorsMvGroup\": {" + LINE_SEP + 
 	"        \"type\": \"object\"," + LINE_SEP + 

--- a/interaction-dsl/com.temenos.interaction.rimdsl.tests/src/com/temenos/interaction/rimdsl/SwaggerGeneratorTest.java
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.tests/src/com/temenos/interaction/rimdsl/SwaggerGeneratorTest.java
@@ -48,154 +48,25 @@ import com.temenos.interaction.rimdsl.rim.DomainModel;
 @RunWith(XtextRunner.class)
 public class SwaggerGeneratorTest {
 	
-	 private final static Logger LOGGER = Logger.getLogger(SwaggerGeneratorTest.class.getName());
+	private final static Logger LOGGER = Logger.getLogger(SwaggerGeneratorTest.class.getName());
 	
 	@Inject 
 	IGenerator underTest;
 	@Inject
 	ParseHelper<DomainModel> parseHelper;
-	
-	private final static String LINE_SEP = System.getProperty("line.separator");
-	
-	private final static String SIMPLE_STATES_RIM = "" +
-	"domain SimpleDomain {" + LINE_SEP +
-	"rim Simple @ Api : tags ( \"Simple\" ) {" + LINE_SEP +
-	"	event POST {" + LINE_SEP +
-	"	    method: POST" + LINE_SEP +
-	"	}" + LINE_SEP +
 
-	"	command GetEntity" + LINE_SEP +
-	"	command GetException" + LINE_SEP +
-	"	command UpdateEntity" + LINE_SEP +
-	
-	" basepath: \"/Simple\"" + LINE_SEP +
-			
-	"initial resource A {" + LINE_SEP +
-	"	type: collection" + LINE_SEP +
-	"	entity: ENTITY" + LINE_SEP +
-	"	view: GetEntity" + LINE_SEP +
-	"	path: \"/A\"" + LINE_SEP +
-	"	POST -> B" + LINE_SEP +
-	"}" + LINE_SEP +
-
-	"exception resource E {" + LINE_SEP +
-	"	type: collection" + LINE_SEP +
-	"	entity: EXCEPTION" + LINE_SEP +
-	"	view: GetException" + LINE_SEP +
-	"}" + LINE_SEP +
-	
-	"resource B {" +
-	"	type: item" + LINE_SEP +
-	"	entity: ENTITY" + LINE_SEP +
-	"	actions [ UpdateEntity ]" + LINE_SEP +
-	"	path: \"/B\"" + LINE_SEP +
-	"}" + LINE_SEP +
-	"}" + LINE_SEP +
-	"}" + LINE_SEP +
-	"";
-
-	private final static String SIMPLE_STATES_SWAGGER = "" +		
-	"{" + LINE_SEP + 
-	"    \"swagger\": \"2.0\"," + LINE_SEP + 
-    "    \"info\": {" + LINE_SEP + 
-    "        \"title\": \"\"," + LINE_SEP + 
-    "        \"description\": \"\"," + LINE_SEP + 
-    "        \"version\": \"1.0.0\"" + LINE_SEP + 
-    "    }," + LINE_SEP + 
-    "    \"produces\": [\"application/json\",\"application/xml\"]," + LINE_SEP + 
-    "\"paths\": {" + LINE_SEP +
-    "\"/B\": {" + LINE_SEP + 
-    "    \"post\": {" + LINE_SEP + 
-    "        \"description\": \"\"," + LINE_SEP + 
-    "        \"consumes\": [\"application/json\",\"application/xml\"]," + LINE_SEP + 
-    "        \"produces\": [\"application/json\",\"application/xml\"]," + LINE_SEP + 
-    "        \"parameters\": [" + LINE_SEP + 
-    "            {" + LINE_SEP + 
-    "                \"in\": \"body\"," + LINE_SEP + 
-    "                \"name\": \"body\"," + LINE_SEP + 
-    "                \"description\": \"-\"," + LINE_SEP + 
-    "                \"required\": true," + LINE_SEP + 
-    "                \"schema\": {" + LINE_SEP + 
-    "                    \"$ref\": \"#/definitions/ENTITY\"" + LINE_SEP + 
-    "                }" + LINE_SEP + 
-    "            }" + LINE_SEP + 
-    "        ]," + LINE_SEP + 
-    "         \"tags\": [\"Simple\"" + LINE_SEP + 
-    "        ]," + LINE_SEP + 
-    "            \"responses\": {" + LINE_SEP + 
-    "            \"201\": {" + LINE_SEP + 
-    "                \"description\": \"Created\"," + LINE_SEP + 
-    "                \"schema\": {" + LINE_SEP + 
-    "                    \"type\": \"array\"," + LINE_SEP + 
-    "                    \"items\": {" + LINE_SEP + 
-    "                        \"$ref\": \"#/definitions/ENTITY\"" + LINE_SEP + 
-    "                    }" + LINE_SEP + 
-    "                }" + LINE_SEP + 
-    "            }," + LINE_SEP + 
-    "            \"400\": {" + LINE_SEP + 
-    "                \"description\": \"Bad request\"," + LINE_SEP + 
-    "                \"schema\": {" + LINE_SEP + 
-    "                    \"type\": \"array\"," + LINE_SEP + 
-    "                    \"items\": {" + LINE_SEP + 
-    "                        \"$ref\": \"#/definitions/ErrorsMvGroup\"" + LINE_SEP + 
-    "                    }" + LINE_SEP + 
-    "                }" + LINE_SEP + 
-    "            }," + LINE_SEP + 
-    "            \"401\": {" + LINE_SEP + 
-    "                \"description\": \"Authentication/Authorization error\"," + LINE_SEP + 
-    "                \"schema\": {" + LINE_SEP + 
-    "                    \"type\": \"array\"," + LINE_SEP + 
-    "                    \"items\": {" + LINE_SEP + 
-    "                        \"$ref\": \"#/definitions/ErrorsMvGroup\"" + LINE_SEP + 
-    "                    }" + LINE_SEP + 
-    "                }" + LINE_SEP + 
-    "            }," + LINE_SEP + 
-    "            \"404\": {" + LINE_SEP + 
-    "                \"description\": \"Resource not found\"" + LINE_SEP + 
-    "            }," + LINE_SEP + 
-    "            \"default\": {" + LINE_SEP + 
-    "                \"description\": \"Unexpected output\"," + LINE_SEP + 
-    "                \"schema\": {" + LINE_SEP + 
-    "                    \"$ref\": \"#/definitions/ErrorsMvGroup\"" + LINE_SEP + 
-    "                }" + LINE_SEP + 
-    "            }" + LINE_SEP + 
-    "        }" + LINE_SEP + 
-    "    }" + LINE_SEP + 
-    "}" + LINE_SEP + 
-    "}," + LINE_SEP + 
-	"\"definitions\": {" + LINE_SEP + 
-	"    \"ErrorsMvGroup\": {" + LINE_SEP + 
-	"        \"type\": \"object\"," + LINE_SEP + 
-	"        \"properties\": {" + LINE_SEP + 
-	"            \"Text\": {" + LINE_SEP + 
-	"                \"type\": \"string\"" + LINE_SEP + 
-	"            }," + LINE_SEP + 
-	"            \"Type\": {" + LINE_SEP + 
-	"                \"type\": \"string\"" + LINE_SEP + 
-	"            }," + LINE_SEP + 
-	"            \"Info\": {" + LINE_SEP + 
-	"                \"type\": \"string\"" + LINE_SEP + 
-	"            }," + LINE_SEP + 
-	"            \"Code\": {" + LINE_SEP + 
-	"                \"type\": \"string\"" + LINE_SEP + 
-	"            }" + LINE_SEP + 
-	"        }" + LINE_SEP + 
-	"    }" + LINE_SEP + 
-	"}" + LINE_SEP + 
-	"}" + LINE_SEP;
-	
 	@Test
 	public void testGenerateSimpleStates() throws Exception {
-		DomainModel domainModel = parseHelper.parse(SIMPLE_STATES_RIM);
+		DomainModel domainModel = parseHelper.parse(loadTestResource("apiSimple.rim"));
 		DomainDeclaration domainDeclaration = (DomainDeclaration) domainModel.getRims().get(0);
 		InMemoryFileSystemAccess fsa = new InMemoryFileSystemAccess();
 		underTest.doGenerate(domainDeclaration.eResource(), fsa);		
-		assertEquals(1, fsa.getFiles().size());	
+		assertEquals(1, fsa.getFiles().size());
 		
 		// the behaviour class
 		String expectedKey = IFileSystemAccess.DEFAULT_OUTPUT + "api-docs-SimpleDomain-Simple.json";
 		assertTrue(fsa.getFiles().containsKey(expectedKey));
-		assertEquals(SIMPLE_STATES_SWAGGER, fsa.getFiles().get(expectedKey).toString());	
+		assertEquals(loadTestResource("api-docs-SimpleDomain-Simple.json"), fsa.getFiles().get(expectedKey));
 	}
 
 	@Test
@@ -211,7 +82,6 @@ public class SwaggerGeneratorTest {
 		assertTrue(fsa.getFiles().containsKey(expectedKey));
 		String output = fsa.getFiles().get(expectedKey).toString();
 		assertTrue(output.contains("/notes"));
-				
 	}
 	
 	private String loadTestRIM() throws IOException {
@@ -219,5 +89,10 @@ public class SwaggerGeneratorTest {
 		String rim = Resources.toString(url, Charsets.UTF_8);
 		return rim;
 	}
-
+	
+	private String loadTestResource(String resource) throws IOException {
+        URL url = Resources.getResource(resource);
+        String file = Resources.toString(url, Charsets.UTF_8);
+        return file;
+    }
 }

--- a/interaction-dsl/com.temenos.interaction.rimdsl.tests/src/com/temenos/interaction/rimdsl/SwaggerGeneratorTest.java
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.tests/src/com/temenos/interaction/rimdsl/SwaggerGeneratorTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.logging.Logger;
 
 import org.eclipse.xtext.generator.IFileSystemAccess;
 import org.eclipse.xtext.generator.IGenerator;
@@ -40,12 +41,14 @@ import org.junit.runner.RunWith;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import com.google.inject.Inject;
+import com.temenos.interaction.rimdsl.rim.DomainDeclaration;
 import com.temenos.interaction.rimdsl.rim.DomainModel;
-import com.temenos.interaction.rimdsl.rim.ResourceInteractionModel;
 
 @InjectWith(RIMDslSwaggerInjectorProvider.class)
 @RunWith(XtextRunner.class)
 public class SwaggerGeneratorTest {
+	
+	 private final static Logger LOGGER = Logger.getLogger(SwaggerGeneratorTest.class.getName());
 	
 	@Inject 
 	IGenerator underTest;
@@ -55,7 +58,8 @@ public class SwaggerGeneratorTest {
 	private final static String LINE_SEP = System.getProperty("line.separator");
 	
 	private final static String SIMPLE_STATES_RIM = "" +
-	"rim Simple {" + LINE_SEP +
+	"domain SimpleDomain {" + LINE_SEP +
+	"rim Simple @ Api : tags ( \"Simple\" ) {" + LINE_SEP +
 	"	event POST {" + LINE_SEP +
 	"	    method: POST" + LINE_SEP +
 	"	}" + LINE_SEP +
@@ -63,6 +67,8 @@ public class SwaggerGeneratorTest {
 	"	command GetEntity" + LINE_SEP +
 	"	command GetException" + LINE_SEP +
 	"	command UpdateEntity" + LINE_SEP +
+	
+	" basepath: \"/Simple\"" + LINE_SEP +
 			
 	"initial resource A {" + LINE_SEP +
 	"	type: collection" + LINE_SEP +
@@ -85,63 +91,123 @@ public class SwaggerGeneratorTest {
 	"	path: \"/B\"" + LINE_SEP +
 	"}" + LINE_SEP +
 	"}" + LINE_SEP +
+	"}" + LINE_SEP +
 	"";
 
 	private final static String SIMPLE_STATES_SWAGGER = "" +		
-	"{" + LINE_SEP +
-	"  \"apiVersion\": \"0.2\"," + LINE_SEP +
-	"  \"swaggerVersion\": \"1.2\"," + LINE_SEP +
-	"\"resourcePath\": \"/A\"," + LINE_SEP +
-	"\"apis\": [" + LINE_SEP +
-	"{" + LINE_SEP +
-	"\"path\": \"/A\"," + LINE_SEP +
-	"\"operations\": [" + LINE_SEP +
-	"{" + LINE_SEP +
-	"\"method\": \"GET\"," + LINE_SEP +
-	"\"nickname\": \"A\"" + LINE_SEP +
-	"}" + LINE_SEP +
-	"]" + LINE_SEP +
-	"}," + LINE_SEP +
-	"{" + LINE_SEP +
-	"\"path\": \"/B\"," + LINE_SEP +
-	"\"operations\": [" + LINE_SEP +
-	"{" + LINE_SEP +
-	"\"method\": \"POST\"," + LINE_SEP +
-	"\"nickname\": \"B\"" + LINE_SEP +
-	"}," + LINE_SEP +
-	"{" + LINE_SEP +
-	"\"method\": \"GET\"," + LINE_SEP +
-	"\"nickname\": \"B\"" + LINE_SEP +
-	"}" + LINE_SEP +
-	"]" + LINE_SEP +
-	"}" + LINE_SEP +
-	"]" + LINE_SEP +
+	"{" + LINE_SEP + 
+	"    \"swagger\": \"2.0\"," + LINE_SEP + 
+	"    \"info\": {" + LINE_SEP + 
+	"        \"title\": \"\"," + LINE_SEP + 
+	"        \"description\": \"\"," + LINE_SEP + 
+	"        \"version\": \"1.0.0\"" + LINE_SEP + 
+	"    }," + LINE_SEP + 
+	"    \"produces\": [\"application/json\",\"application/xml\"]," + LINE_SEP + 
+	"\"paths\": {" + LINE_SEP +
+	"    \"/B\": {" + LINE_SEP + 
+	"        \"post\": {" + LINE_SEP + 
+	"            \"description\": \"\"," + LINE_SEP + 
+	"            \"consumes\": [\"application/json\",\"application/xml\"]," + LINE_SEP + 
+	"            \"produces\": [\"application/json\",\"application/xml\"]," + LINE_SEP + 
+	"            \"parameters\": [" + LINE_SEP + 
+	"                {" + LINE_SEP + 
+	"                    \"in\": \"body\"," + LINE_SEP + 
+	"                    \"name\": \"body\"," + LINE_SEP + 
+	"                    \"description\": \"-\"," + LINE_SEP + 
+	"                    \"required\": true," + LINE_SEP + 
+	"                    \"schema\": {" + LINE_SEP + 
+	"                        \"$ref\": \"#/definitions/ENTITY\"" + LINE_SEP + 
+	"                    }" + LINE_SEP + 
+	"                }" + LINE_SEP + 
+	"            ]," + LINE_SEP + 
+	"             \"tags\": [\"Simple\"" + LINE_SEP + 
+	"            ]," + LINE_SEP + 
+	"                \"responses\": {" + LINE_SEP + 
+	"                \"201\": {" + LINE_SEP + 
+	"                    \"description\": \"Created\"," + LINE_SEP + 
+	"                    \"schema\": {" + LINE_SEP + 
+	"                        \"type\": \"array\"," + LINE_SEP + 
+	"                        \"items\": {" + LINE_SEP + 
+	"                            \"$ref\": \"#/definitions/ENTITY\"" + LINE_SEP + 
+	"                        }" + LINE_SEP + 
+	"                    }" + LINE_SEP + 
+	"                }," + LINE_SEP + 
+	"                \"400\": {" + LINE_SEP + 
+	"                    \"description\": \"Bad request\"," + LINE_SEP + 
+	"                    \"schema\": {" + LINE_SEP + 
+	"                        \"type\": \"array\"," + LINE_SEP + 
+	"                        \"items\": {" + LINE_SEP + 
+	"                            \"$ref\": \"#/definitions/ErrorsMvGroup\"" + LINE_SEP + 
+	"                        }" + LINE_SEP + 
+	"                    }" + LINE_SEP + 
+	"                }," + LINE_SEP + 
+	"                \"401\": {" + LINE_SEP + 
+	"                    \"description\": \"Authentication/Authorization error\"," + LINE_SEP + 
+	"                    \"schema\": {" + LINE_SEP + 
+	"                        \"type\": \"array\"," + LINE_SEP + 
+	"                        \"items\": {" + LINE_SEP + 
+	"                            \"$ref\": \"#/definitions/ErrorsMvGroup\"" + LINE_SEP + 
+	"                        }" + LINE_SEP + 
+	"                    }" + LINE_SEP + 
+	"                }," + LINE_SEP + 
+	"                \"404\": {" + LINE_SEP + 
+	"                    \"description\": \"Resource not found\"" + LINE_SEP + 
+	"                }," + LINE_SEP + 
+	"                \"default\": {" + LINE_SEP + 
+	"                    \"description\": \"Unexpected output\"," + LINE_SEP + 
+	"                    \"schema\": {" + LINE_SEP + 
+	"                        \"$ref\": \"#/definitions/ErrorsMvGroup\"" + LINE_SEP + 
+	"                    }" + LINE_SEP + 
+	"                }" + LINE_SEP + 
+	"            }" + LINE_SEP + 
+	"        }" + LINE_SEP + 
+	"    }" + LINE_SEP + 
+	"}," + LINE_SEP + 
+	"\"definitions\": {" + LINE_SEP + 
+	"    \"ErrorsMvGroup\": {" + LINE_SEP + 
+	"        \"type\": \"object\"," + LINE_SEP + 
+	"        \"properties\": {" + LINE_SEP + 
+	"            \"Text\": {" + LINE_SEP + 
+	"                \"type\": \"string\"" + LINE_SEP + 
+	"            }," + LINE_SEP + 
+	"            \"Type\": {" + LINE_SEP + 
+	"                \"type\": \"string\"" + LINE_SEP + 
+	"            }," + LINE_SEP + 
+	"            \"Info\": {" + LINE_SEP + 
+	"                \"type\": \"string\"" + LINE_SEP + 
+	"            }," + LINE_SEP + 
+	"            \"Code\": {" + LINE_SEP + 
+	"                \"type\": \"string\"" + LINE_SEP + 
+	"            }" + LINE_SEP + 
+	"        }" + LINE_SEP + 
+	"    }" + LINE_SEP + 
+	"}" + LINE_SEP + 
 	"}" + LINE_SEP;
 	
 	@Test
 	public void testGenerateSimpleStates() throws Exception {
 		DomainModel domainModel = parseHelper.parse(SIMPLE_STATES_RIM);
-		ResourceInteractionModel model = (ResourceInteractionModel) domainModel.getRims().get(0);
+		DomainDeclaration domainDeclaration = (DomainDeclaration) domainModel.getRims().get(0);
 		InMemoryFileSystemAccess fsa = new InMemoryFileSystemAccess();
-		underTest.doGenerate(model.eResource(), fsa);
-		assertEquals(1, fsa.getFiles().size());
+		underTest.doGenerate(domainDeclaration.eResource(), fsa);		
+		assertEquals(1, fsa.getFiles().size());	
 		
 		// the behaviour class
-		String expectedKey = IFileSystemAccess.DEFAULT_OUTPUT + "api-docs.json";
+		String expectedKey = IFileSystemAccess.DEFAULT_OUTPUT + "api-docs-SimpleDomain-Simple.json";
 		assertTrue(fsa.getFiles().containsKey(expectedKey));
-		assertEquals(SIMPLE_STATES_SWAGGER, fsa.getFiles().get(expectedKey).toString());
-				
+		assertEquals(SIMPLE_STATES_SWAGGER, fsa.getFiles().get(expectedKey).toString());	
 	}
 
 	@Test
 	public void testGenerateSimple() throws Exception {
 		DomainModel domainModel = parseHelper.parse(loadTestRIM());
+		DomainDeclaration domainDeclaration = (DomainDeclaration) domainModel.getRims().get(0);
 		InMemoryFileSystemAccess fsa = new InMemoryFileSystemAccess();
-		underTest.doGenerate(domainModel.eResource(), fsa);
+		underTest.doGenerate(domainDeclaration.eResource(), fsa);
 		assertEquals(1, fsa.getFiles().size());
 		
 		// the behaviour class
-		String expectedKey = IFileSystemAccess.DEFAULT_OUTPUT + "api-docs.json";
+		String expectedKey = IFileSystemAccess.DEFAULT_OUTPUT + "api-docs-SimpleModel-Simple.json";
 		assertTrue(fsa.getFiles().containsKey(expectedKey));
 		String output = fsa.getFiles().get(expectedKey).toString();
 		assertTrue(output.contains("/notes"));

--- a/interaction-dsl/com.temenos.interaction.rimdsl.tests/src/com/temenos/interaction/rimdsl/formatting/FormatterTest.java
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.tests/src/com/temenos/interaction/rimdsl/formatting/FormatterTest.java
@@ -21,6 +21,7 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import com.temenos.interaction.rimdsl.RIMDslInjectorProvider;
 import com.temenos.interaction.rimdsl.rim.DomainModel;
+import com.temenos.interaction.rimdsl.rim.DomainDeclaration;
 import java.io.BufferedReader;
 import java.io.StringReader;
 import java.util.ArrayList;
@@ -34,7 +35,7 @@ import java.util.List;
 @RunWith(XtextRunner.class)
 @InjectWith(RIMDslInjectorProvider.class)
 public class FormatterTest {
-
+    
     @Inject
     ParseHelper<DomainModel> parser;
 
@@ -45,7 +46,8 @@ public class FormatterTest {
     public void testFormatting() throws Exception {
         String text = loadTestRIM("Simple.rim");
         DomainModel domainModel = parser.parse(text);
-        IParseResult parseResult = ((XtextResource) domainModel.eResource()).getParseResult();
+        DomainDeclaration domainDeclaration = (DomainDeclaration) domainModel.getRims().get(0);
+        IParseResult parseResult = ((XtextResource) domainDeclaration.eResource()).getParseResult();
         assertNotNull(parseResult);
         ICompositeNode rootNode = parseResult.getRootNode();
         String formattedText = formatter.format(rootNode, 0, text.length()).getFormattedText();

--- a/interaction-dsl/com.temenos.interaction.rimdsl/src/com/temenos/interaction/rimdsl/RIMDsl.xtext
+++ b/interaction-dsl/com.temenos.interaction.rimdsl/src/com/temenos/interaction/rimdsl/RIMDsl.xtext
@@ -7,7 +7,7 @@ DomainModel:
 ;
 
 DomainDeclaration:
-    'domain' name = QualifiedName '{'
+    'domain' name = QualifiedName (annotations+=MdfAnnotation)* '{'
         (rims += Ref)*
     '}'
 ;
@@ -29,7 +29,7 @@ QualifiedNameWithWildcard:
 ;
 
 ResourceInteractionModel:
-    'rim' name = ID '{'
+    'rim' name = ID (annotations+=MdfAnnotation)* '{'
     	// elements can appear in any order
     	(
 	        (events += Event)*
@@ -41,9 +41,8 @@ ResourceInteractionModel:
        	)
     '}'
 ;
-
 Event:
-	'event' name=ID '{' 
+	'event' name=ID (annotations+=MdfAnnotation)* '{' 
      	'method:' httpMethod=ID
     '}'
 ;
@@ -84,7 +83,7 @@ Relation:
     '}'	
 ;
 State: 
-    (isInitial?='initial' | isException?='exception')? 'resource' name=ID '{'
+    (isInitial?='initial' | isException?='exception')? 'resource' name=ID (annotations+=MdfAnnotation)* '{'
     	// elements can appear in any order
     	(
             // MUST define a 'type:'
@@ -115,7 +114,7 @@ ImplRef:
 			// actions [ SomeCommand, AnotherCommand ]
 			| ('actions' '[' ((actions+=ResourceCommand) (',' actions+=ResourceCommand)* ) ']')
 			// commands [ GET: SomeCommand ]
-            | ('commands' '[' ((methods+=MethodRef) (',' methods+=MethodRef)* ) ']')
+            | ('commands' ':'? '[' ((methods+=MethodRef) (',' methods+=MethodRef)* ) ']')
 	)
 ;
 
@@ -284,4 +283,7 @@ terminal DQ_STRING	:
 				| !('\\'|'"')
 			)* '"'
 		; 
+
+MdfAnnotation returns MdfAnnotation:
+    '@'    namespace=ID ':' name=ID ('(' properties+=DQ_STRING (',' properties+=DQ_STRING)* ')')?;
 

--- a/interaction-dsl/com.temenos.interaction.rimdsl/src/com/temenos/interaction/rimdsl/formatting/RIMDslFormatter.java
+++ b/interaction-dsl/com.temenos.interaction.rimdsl/src/com/temenos/interaction/rimdsl/formatting/RIMDslFormatter.java
@@ -47,18 +47,18 @@ public class RIMDslFormatter extends AbstractDeclarativeFormatter {
 
 		// indent the domain {} block
 		setIndentationIncrementAndDecrementAndLinewrapAfter(c,
-				f.getDomainDeclarationAccess().getLeftCurlyBracketKeyword_2(),
-				f.getDomainDeclarationAccess().getRightCurlyBracketKeyword_4());
+				f.getDomainDeclarationAccess().getLeftCurlyBracketKeyword_3(),
+				f.getDomainDeclarationAccess().getRightCurlyBracketKeyword_5());
 
 		// indent the rim {} block
 		setIndentationIncrementAndDecrementAndLinewrapAfter(c,
-				f.getResourceInteractionModelAccess().getLeftCurlyBracketKeyword_2(),
-				f.getResourceInteractionModelAccess().getRightCurlyBracketKeyword_4());
+				f.getResourceInteractionModelAccess().getLeftCurlyBracketKeyword_3(),
+				f.getResourceInteractionModelAccess().getRightCurlyBracketKeyword_5());
 
 		// indent the resource {} block
 		setIndentationIncrementAndDecrementAndLinewrapAfter(c,
-				f.getStateAccess().getLeftCurlyBracketKeyword_3(),
-				f.getStateAccess().getRightCurlyBracketKeyword_5());
+				f.getStateAccess().getLeftCurlyBracketKeyword_4(),
+				f.getStateAccess().getRightCurlyBracketKeyword_6());
 
 		// indent the transition {} block
 		setIndentationIncrementAndDecrementAndLinewrapAfter(c,

--- a/interaction-dsl/com.temenos.interaction.rimdsl/src/com/temenos/interaction/rimdsl/generator/RIMDslGeneratorSwagger.xtend
+++ b/interaction-dsl/com.temenos.interaction.rimdsl/src/com/temenos/interaction/rimdsl/generator/RIMDslGeneratorSwagger.xtend
@@ -34,7 +34,6 @@ class RIMDslGeneratorSwagger implements IGenerator {
 	    if (resource == null) {
             throw new RuntimeException("Generator called with null resource");	        
 	    }
-	    var basepathapi = resource.allContents.toIterable.filter(typeof(BasePath))
 	    var domains = resource.allContents.toIterable.filter(typeof(DomainDeclaration))
 	    
 	    for (DomainDeclaration domain : domains) {
@@ -56,7 +55,7 @@ class RIMDslGeneratorSwagger implements IGenerator {
                                 resources.add(path)
                             }
                         }
-                        fsa.generateFile("api-docs-"+domain.name+"-"+rim.name+".json", toApiDocHeader(domain, rim) + toResourceListing(basepathapi, rim, initialState, resources, interactionsByPath, stateByMethodPath).toString + toApiDocFooter())
+                        fsa.generateFile("api-docs-"+domain.name+"-"+rim.name+".json", toApiDocHeader(domain, rim) + toResourceListing(rim, initialState, resources, interactionsByPath, stateByMethodPath).toString + toApiDocFooter())
                     } 
 	            }
 	        }
@@ -67,28 +66,26 @@ class RIMDslGeneratorSwagger implements IGenerator {
     {
         "swagger": "2.0",
         "info": {
-            "title": "«getAnnotation(domain.annotations,"title")»",
-            "description": "«getAnnotation(domain.annotations,"description")»",
+            "title": "«getAnnotation(rim.annotations,"title")»",
+            "description": "«getAnnotation(rim.annotations,"description")»",
             "version": "1.0.0"
         },
         "produces": ["application/json","application/xml"],
 	'''
 
-    def toResourceListing(Iterable<BasePath> basepathapis, ResourceInteractionModel rim, State initialState, Iterable<String> paths, Map<String, Set<String>> interactionsByPath, Map<String, State> stateByMethodPath) '''
-        «FOR basepathapi : basepathapis»
+    def toResourceListing(ResourceInteractionModel rim, State initialState, Iterable<String> paths, Map<String, Set<String>> interactionsByPath, Map<String, State> stateByMethodPath) '''
         "paths": {
-            «setPathPosition(0)»
-            «FOR path : paths»
-                «IF path != null && showResource(path,rim,interactionsByPath,stateByMethodPath)»
-                    «var interactions = interactionsByPath.get(path)»
-                    «IF interactions != null»
-                        "«path»": {
-                            «toOperations(path, rim, interactionsByPath, stateByMethodPath)»
-                        }
-                        «IF positionPath < paths.size - 1»,«setPathPosition(positionPath+1)»«ENDIF»
-                    «ENDIF»
+        «setPathPosition(0)»
+        «FOR path : paths»
+            «IF path != null && showResource(path,rim,interactionsByPath,stateByMethodPath)»
+                «var interactions = interactionsByPath.get(path)»
+                «IF interactions != null»
+                    "«path»": {
+                        «toOperations(path, rim, interactionsByPath, stateByMethodPath)»
+                    }
+                    «IF positionPath < paths.size - 1»,«setPathPosition(positionPath+1)»«ENDIF»
                 «ENDIF»
-            «ENDFOR»
+            «ENDIF»
         «ENDFOR»
         },
         "definitions": {

--- a/interaction-dsl/com.temenos.interaction.rimdsl/src/com/temenos/interaction/rimdsl/generator/RIMDslGeneratorSwagger.xtend
+++ b/interaction-dsl/com.temenos.interaction.rimdsl/src/com/temenos/interaction/rimdsl/generator/RIMDslGeneratorSwagger.xtend
@@ -14,66 +14,263 @@ import java.util.Set
 import org.eclipse.emf.ecore.resource.Resource
 import org.eclipse.xtext.generator.IFileSystemAccess
 import org.eclipse.xtext.generator.IGenerator
+import com.temenos.interaction.rimdsl.rim.ResourceInteractionModel
+import com.temenos.interaction.rimdsl.rim.BasePath
+import java.util.regex.Pattern
+import com.temenos.interaction.rimdsl.rim.DomainDeclaration
+import com.temenos.interaction.rimdsl.rim.Ref
+import org.apache.commons.lang.StringUtils
+import org.eclipse.emf.common.util.EList
+import com.temenos.interaction.rimdsl.rim.MdfAnnotation
 
 class RIMDslGeneratorSwagger implements IGenerator {
+    
+    var nextComma = false;
+    var positionPath = 0;
+    var metadata = new HashMap<String, Object>();
 	
 	override void doGenerate(Resource resource, IFileSystemAccess fsa) {
+	    
 	    if (resource == null) {
             throw new RuntimeException("Generator called with null resource");	        
 	    }
-	    var states = resource.allContents.toIterable.filter(typeof(State))
-	    var initialState = states.findFirst[ isInitial ]
-	    if (initialState != null) {
-		    var interactionsByPath = new HashMap<String, Set<String>>()
-		    collectInteractionsByPath(interactionsByPath, initialState)
-		    var stateByMethodPath = new HashMap<String, State>()
-		    collectStateByMethodPath(stateByMethodPath, initialState)
-		    var resources = new ArrayList<String>()
-		    for (String path : interactionsByPath.keySet) {
-		    	if (path.startsWith("/")) {
-		    		resources.add(path)
-		    	}
-		    }
-		    fsa.generateFile("api-docs.json", toApiDocHeader() + toResourceListing(initialState, resources, interactionsByPath, stateByMethodPath).toString + toApiDocFooter())
+	    var basepathapi = resource.allContents.toIterable.filter(typeof(BasePath))
+	    var domains = resource.allContents.toIterable.filter(typeof(DomainDeclaration))
+	    
+	    for (DomainDeclaration domain : domains) {
+	        var refs = domain.rims
+	        for (Ref ref : refs) {
+	            if(ref instanceof ResourceInteractionModel) {	                
+	                var rim = ref as ResourceInteractionModel
+                    var states = rim.states
+                    var initialState = states.findFirst[ isInitial ]
+                    metadata = resource.resourceSet.loadOptions.get("Metadata") as HashMap<String, Object>
+                    if (initialState != null) {
+                        var interactionsByPath = new HashMap<String, Set<String>>()
+                        collectInteractionsByPath(interactionsByPath, initialState)
+                        var stateByMethodPath = new HashMap<String, State>()
+                        collectStateByMethodPath(stateByMethodPath, initialState)
+                        var resources = new ArrayList<String>()
+                        for (String path : interactionsByPath.keySet) {
+                            if (path.startsWith("/")) {
+                                resources.add(path)
+                            }
+                        }
+                        fsa.generateFile("api-docs-"+domain.name+"-"+rim.name+".json", toApiDocHeader(domain, rim) + toResourceListing(basepathapi, rim, initialState, resources, interactionsByPath, stateByMethodPath).toString + toApiDocFooter())
+                    } 
+	            }
+	        }
 	    }
 	}
 	
-	def toApiDocHeader() '''
-		{
-		  "apiVersion": "0.2",
-		  "swaggerVersion": "1.2",
+	def toApiDocHeader(DomainDeclaration domain, ResourceInteractionModel rim) '''
+    {
+        "swagger": "2.0",
+        "info": {
+            "title": "«getAnnotation(domain.annotations,"title")»",
+            "description": "«getAnnotation(domain.annotations,"description")»",
+            "version": "1.0.0"
+        },
+        "produces": ["application/json","application/xml"],
 	'''
 
-	def toApiDocFooter() '''
-		}
-	'''
-	
-	def toResourceListing(State initialState, Iterable<String> paths, Map<String, Set<String>> interactionsByPath, Map<String, State> stateByMethodPath) '''
-	    "resourcePath": "«initialState.path.name»",
-	    "apis": [
-        «FOR path : paths SEPARATOR ','»
-          «IF path != null»
-          « var interactions = interactionsByPath.get(path)»
-    		{
-    		"path": "«path»"«IF interactions != null»,
-    		«toOperations(path, interactionsByPath, stateByMethodPath)»«ENDIF»
-    		}
-          «ENDIF»
+    def toResourceListing(Iterable<BasePath> basepathapis, ResourceInteractionModel rim, State initialState, Iterable<String> paths, Map<String, Set<String>> interactionsByPath, Map<String, State> stateByMethodPath) '''
+        «FOR basepathapi : basepathapis»
+        "paths": {
+            «setPathPosition(0)»
+            «FOR path : paths»
+                «IF path != null && showResource(path,rim,interactionsByPath,stateByMethodPath)»
+                    «var interactions = interactionsByPath.get(path)»
+                    «IF interactions != null»
+                        "«path»": {
+                            «toOperations(path, rim, interactionsByPath, stateByMethodPath)»
+                        }
+                        «IF positionPath < paths.size - 1»,«setPathPosition(positionPath+1)»«ENDIF»
+                    «ENDIF»
+                «ENDIF»
+            «ENDFOR»
         «ENDFOR»
-	    ]
-  '''
+        },
+        "definitions": {
+            "ErrorsMvGroup": {
+                "type": "object",
+                "properties": {
+                    "Text": {
+                        "type": "string"
+                    },
+                    "Type": {
+                        "type": "string"
+                    },
+                    "Info": {
+                        "type": "string"
+                    },
+                    "Code": {
+                        "type": "string"
+                    }
+                }
+            }
+            «FOR path : paths»
+                «IF path != null»
+                    «FOR method : interactionsByPath.get(path)»
+                        «var state = stateByMethodPath.get(path + method)»
+                        «var entity = state.entity»
+                        «IF null != metadata && metadata.containsKey(entity.name)»
+                            «var entityProps = metadata.get(entity.name) as HashMap<String, Object>»
+                            «IF entityProps != null»
+                                ,
+                                «paramsPrint(entity.name, entityProps)»
+                                «removeEntry(entity.name)»
+                            «ENDIF»
+                        «ENDIF»
+                    «ENDFOR»
+                «ENDIF»
+            «ENDFOR»
+        }
+    '''
 
-	def toOperations(String path, Map<String, Set<String>> interactionsByPath, Map<String, State> stateByMethodPath) '''
-	    "operations": [
-        «FOR method : interactionsByPath.get(path) SEPARATOR ','»
-          « var state = stateByMethodPath.get(path + method)»
-   		  {
-   		  "method": "«method»",
-   		  "nickname": "«IF state != null»«state.name»«ENDIF»"
-   		  }
-        «ENDFOR»
-	    ]
-  '''
+	def toOperations(String path, ResourceInteractionModel rim, Map<String, Set<String>> interactionsByPath, Map<String, State> stateByMethodPath) '''
+    «FOR method : interactionsByPath.get(path) SEPARATOR ','»
+        "«method.toLowerCase»": {
+            «var state = stateByMethodPath.get(path + method)»
+            «var methods = state.impl.methods»
+            "description": "«getAnnotation(state.annotations,"description")»",
+            «IF method == "POST" || method == "PUT"»
+            "consumes": ["application/json","application/xml"],
+            "produces": ["application/json","application/xml"],
+            «ELSE»
+            "produces": ["application/json","application/xml"],
+            «ENDIF»
+            "parameters": [
+                «setNextComma(false)» 
+                «FOR methodCommand : methods»
+                    «FOR propertie : methodCommand.command.properties SEPARATOR ','»
+                    {
+                        "name": "«propertie.name»",
+                        "in": "query",
+                        "required": false,
+                        "type": "string",
+                        "default" : ""
+                    }
+                    «setNextComma(true)» 
+                    «ENDFOR»
+                «ENDFOR»
+                «IF path.contains("{") »
+                    «var pattern = Pattern.compile("(?:.*\\{)(.*)(?:\\}.*)")»
+                    «var matcher = pattern.matcher(path)»
+                    «IF matcher.find()»
+                        «var value = matcher.group(1)»
+                        «IF nextComma»,«ENDIF»
+                        {
+                            "name": "«value»",
+                            "in": "path",
+                            "description": "",
+                            "required": true,
+                            "type": "string"
+                        }
+                        «setNextComma(true)» 
+                    «ENDIF»
+                «ENDIF»
+                «IF method == "POST" || method == "PUT"»
+                    «IF nextComma»,«ENDIF»
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "description": "-",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/«state.entity.name»"
+                        }
+                    }
+                    «setNextComma(true)» 
+                «ENDIF»
+            ],
+            «IF findAnnotation(state.annotations,"tags")» "tags": [«getTags(state.annotations)»],
+            «ELSEIF findAnnotation(rim.annotations,"tags")» "tags": [«getTags(rim.annotations)»],
+            «ELSE» "tags": ["«rim.name»"],
+            «ENDIF»
+            "responses": {
+                «IF method == "POST"»
+                "201": {
+                    "description": "Created",
+                    "schema": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/«state.entity.name»"
+                        }
+                    }
+                },
+                «ELSE»
+                "200": {
+                    "description": "",
+                    "schema": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/«state.entity.name»"
+                        }
+                    }
+                },
+                «ENDIF»
+                "400": {
+                    "description": "Bad request",
+                    "schema": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/ErrorsMvGroup"
+                        }
+                    }
+                },
+                "401": {
+                    "description": "Authentication/Authorization error",
+                    "schema": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/ErrorsMvGroup"
+                        }
+                    }
+                },
+                "404": {
+                    "description": "Resource not found"
+                },
+                "default": {
+                    "description": "Unexpected output",
+                    "schema": {
+                        "$ref": "#/definitions/ErrorsMvGroup"
+                    }
+                }
+            }
+        }
+    «ENDFOR»
+    '''
+      
+    def toApiDocFooter() '''
+    }
+    '''
+    
+    def void setPathPosition(int value) {
+        this.positionPath = value;
+    }
+    
+    def void setNextComma (boolean set) {
+        this.nextComma = set;
+    }
+    
+    def void removeEntry (String entry) {
+        this.metadata.remove(entry);
+    }
+    
+    def boolean showResource(String path, ResourceInteractionModel rim, Map<String, Set<String>> interactionsByPath, Map<String, State> stateByMethodPath) {
+        
+        var showResource = false;
+        
+        if(findAnnotation(rim.annotations, "tags")) {
+               showResource = true;
+        } else {
+            for(String method : interactionsByPath.get(path)) {
+                showResource =  findAnnotation(stateByMethodPath.get(path + method).annotations, "tags");
+            }
+        }
+        return showResource;
+    }
   
 	def void collectInteractionsByPath(Map<String, Set<String>> result, State initial) {
 		var states = new ArrayList<State>();
@@ -83,13 +280,10 @@ class RIMDslGeneratorSwagger implements IGenerator {
 	def void collectInteractionsByPath(Map<String, Set<String>> result, Collection<State> states, State currentState) {
 		if (currentState == null || states.contains(currentState)) return;
 		states.add(currentState);
-		// every state must have a 'GET' interaction
 		var sPath = getPath(currentState)
 		var interactions = result.get(sPath);
 		if (interactions == null)
 			interactions = new HashSet<String>();
-		interactions.add("GET");
-		result.put(sPath, interactions);
 		
 		// add interactions by iterating through the transitions from this state
 		for (TransitionRef t : currentState.transitions) {
@@ -127,10 +321,6 @@ class RIMDslGeneratorSwagger implements IGenerator {
 	def void collectStateByMethodPath(Map<String, State> result, Collection<State> states, State currentState) {
 		if (currentState == null || states.contains(currentState)) return;
 		states.add(currentState);
-		// every state must have a 'GET' interaction
-		var sPath = getPath(currentState)
-		result.put(sPath + "GET", currentState);
-		// add interactions by iterating through the transitions from this state
 		for (TransitionRef t : currentState.transitions) {
 			if(t.state != null) {
 				var path = getPath(t.state)
@@ -142,5 +332,79 @@ class RIMDslGeneratorSwagger implements IGenerator {
 		}		
 	}
 	
+	def paramsPrint(String entityName, HashMap<String, Object> entityProps) '''
+    "«entityName»":  {
+        "type": "object",
+        "properties": {
+            «FOR property : entityProps.keySet SEPARATOR ','»
+            "«property»" : {
+                «IF entityProps.get(property) instanceof String»
+                "type" : "«entityProps.get(property)»"
+                «ELSE»
+                «var drilldown = entityProps.get(property) as HashMap<String, Object>»
+                «paramDrillPrint(drilldown)»
+                «ENDIF»
+            }
+            «ENDFOR»
+        }
+    }
+	'''
+	
+	def paramDrillPrint(HashMap<String, Object> drilldown) '''
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties" : {
+            «FOR property : drilldown.keySet SEPARATOR ','»
+            "«property»" : {
+                «IF drilldown.get(property) instanceof String»
+                    "type" : "«drilldown.get(property)»"
+                «ELSE»
+                    «var drill = drilldown.get(property) as HashMap<String, Object>»
+                    «paramDrillPrint(drill)»
+                «ENDIF»
+             }
+            «ENDFOR»
+        }
+    }
+	'''
+	
+    def String getAnnotation (EList<MdfAnnotation> annotations, String name) {
+        
+        var value = "";
+        
+        if (annotations != null && annotations.size > 0) {
+            for (MdfAnnotation annotation : annotations) {
+                if(annotation.namespace.equals("Api") && annotation.name.equals(name)) {
+                    value = annotation.properties.get(0);
+                }
+            }
+        }
+        
+        return value; 
+    }
+        
+    def boolean findAnnotation (EList<MdfAnnotation> annotations, String name) {
+        for (MdfAnnotation annotation : annotations) {
+            if (annotation.namespace.equals("Api") && annotation.name.equals(name)) {
+                return true;
+            }
+        }
+    }
+    
+    	
+    def getTags (EList<MdfAnnotation> annotations) '''
+        «IF annotations != null»
+            «FOR MdfAnnotation annotation : annotations»
+                «IF annotation.namespace.equals("Api") && annotation.name.equals("tags")»
+                    «FOR String tag : annotation.properties SEPARATOR ','»
+                        "«tag»"
+                    «ENDFOR»
+                «ENDIF»
+            «ENDFOR»
+        «ELSE»
+        ""
+        «ENDIF»
+    '''
 }
 

--- a/interaction-sdk-rim-plugin/src/main/java/com/temenos/interaction/sdk/plugin/RIMGeneratorMojo.java
+++ b/interaction-sdk-rim-plugin/src/main/java/com/temenos/interaction/sdk/plugin/RIMGeneratorMojo.java
@@ -29,9 +29,11 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 
 import com.google.inject.Injector;
+import com.temenos.interaction.core.entity.Metadata;
+import com.temenos.interaction.core.resource.ResourceMetadataManager;
 import com.temenos.interaction.rimdsl.RIMDslStandaloneSetup;
-import com.temenos.interaction.rimdsl.RIMDslStandaloneSetupSwagger;
 import com.temenos.interaction.rimdsl.RIMDslStandaloneSetupSpringPRD;
+import com.temenos.interaction.rimdsl.RIMDslStandaloneSetupSwagger;
 import com.temenos.interaction.rimdsl.generator.launcher.Generator;
 import com.temenos.interaction.rimdsl.generator.launcher.ValidatorEventListener;
 
@@ -149,9 +151,11 @@ public class RIMGeneratorMojo extends AbstractMojo {
     			swaggerTargetDirectory.mkdirs();
     		}
     		Injector injector = new RIMDslStandaloneSetupSwagger().createInjectorAndDoEMFRegistration();
+    		ResourceMetadataManager metadataManager = new ResourceMetadataManager();
+    		Metadata metadata = new Metadata(metadataManager);
     		Generator generator = injector.getInstance(Generator.class);
     		if (rimSourceDir != null) {
-        		ok = generator.runGeneratorDir(rimSourceDir.toString(), swaggerTargetDirectory.toString());
+        		ok = generator.runGeneratorDir(rimSourceDir.toString(), metadata, swaggerTargetDirectory.toString());
     		} else {
         		ok = generator.runGenerator(rimSourceFile.toString(), swaggerTargetDirectory.toString());
     		}


### PR DESCRIPTION
Changes:

1. Extension of the rim grammar to enable the usage of annotations. The first usage of the annotation is to create some parts of the swagger api document based on the annotations present on the RIM.
2. Enable on swagger document generation time, the read of metadata to create the schema definition used on the document. This allows to map resources to the actual entity used and present them on the swagger UI.
3. Refactor of the actual swagger generator in order to produce a document that:

 Follows the swagger 2.0 spec
- Brings to the Swagger UI the schema definition associated with the operation/method used based on the metadata for the entity defined on the RIM
- Generates multiple documents for multiples RIM's (different api's) and enhances the Swagger UI experience allowing the access to all the documents using a drop box instead the default url form present on Swagger UI page.
