### PR TITLE
1883357 - Remove validation on self link from HalProvider

### DIFF
--- a/interaction-examples/interaction-hateoas-banking/src/test/java/com/interaction/example/hateoas/banking/HypermediaITCase.java
+++ b/interaction-examples/interaction-hateoas-banking/src/test/java/com/interaction/example/hateoas/banking/HypermediaITCase.java
@@ -205,17 +205,20 @@ public class HypermediaITCase extends JerseyTest {
 	}
 
 	/**
-	 * Attempt to PUT an invalid resource representation.  The supplied self link is not correctly formed.
-	 * This test is no longer required as validation of self link is not mandatory nor mentioned in HAL specification.
+	 * Test to ensure that having a different self link from the target resource does
+	 * not prevent successful processing.
+	 * @throws Exception
 	 */
-	public void putInvalidResource() throws Exception {
-		RepresentationFactory representationFactory = new StandardRepresentationFactory();
-		ReadableRepresentation r = representationFactory.newRepresentation("~/xyz/123");
-		String halRequest = r.toString(RepresentationFactory.HAL_XML);
-		
-		// attempt to put to the notes collection, rather than an individual
-		ClientResponse response = webResource.path("/fundtransfers").type(MediaType.APPLICATION_HAL_XML).put(ClientResponse.class, halRequest);
-        assertEquals(400, response.getStatus());
+	@Test
+	public void putFundTransferHalJSONWithDifferentSelfLink() throws Exception {		
+	    double d = Math.random() * 10000000;
+        String id = Integer.toString((int) d);
+        String halRequest = buildHalResource("DifferentSelfLink", id).toString(RepresentationFactory.HAL_JSON);
+        String resourceUri = "/fundtransfers/" + id;        
+        ClientResponse response = webResource.path(resourceUri).accept(MediaType.APPLICATION_HAL_JSON).type(MediaType.APPLICATION_HAL_JSON).put(ClientResponse.class, halRequest);
+        assertEquals(200, response.getStatus());
+        response = webResource.path("/fundtransfers/" + id).accept(MediaType.APPLICATION_HAL_JSON).get(ClientResponse.class);
+        assertEquals(Response.Status.Family.SUCCESSFUL, Response.Status.fromStatusCode(response.getStatus()).getFamily());
 	}
 
 }

--- a/interaction-examples/interaction-hateoas-banking/src/test/java/com/interaction/example/hateoas/banking/HypermediaITCase.java
+++ b/interaction-examples/interaction-hateoas-banking/src/test/java/com/interaction/example/hateoas/banking/HypermediaITCase.java
@@ -206,8 +206,8 @@ public class HypermediaITCase extends JerseyTest {
 
 	/**
 	 * Attempt to PUT an invalid resource representation.  The supplied self link is not correctly formed.
+	 * This test is no longer required as validation of self link is not mandatory nor mentioned in HAL specification.
 	 */
-	@Test
 	public void putInvalidResource() throws Exception {
 		RepresentationFactory representationFactory = new StandardRepresentationFactory();
 		ReadableRepresentation r = representationFactory.newRepresentation("~/xyz/123");

--- a/interaction-media-hal/src/main/java/com/temenos/interaction/media/hal/HALProvider.java
+++ b/interaction-media-hal/src/main/java/com/temenos/interaction/media/hal/HALProvider.java
@@ -680,9 +680,7 @@ public class HALProvider implements MessageBodyReader<RESTResource>, MessageBody
 		try {
 			// create the hal resource
 			String baseUri = uriInfo.getBaseUri().toString();
-			ReadableRepresentation halResource = representationFactory.readRepresentation(mediaType.toString(), new InputStreamReader(entityStream));
-			// assume the client providing the representation knows something we don't
-			String halresourcePath = halResource.getResourceLink() != null ? halResource.getResourceLink().getHref() : null;
+			ReadableRepresentation halResource = representationFactory.readRepresentation(mediaType.toString(), new InputStreamReader(entityStream));			
 			
 			String resourcePath = uriInfo.getPath();
 						
@@ -698,12 +696,6 @@ public class HALProvider implements MessageBodyReader<RESTResource>, MessageBody
 			 */
 			if (!resourcePath.startsWith("/")) {
 				resourcePath = "/" + resourcePath;
-			}
-			
-			if (halresourcePath != null) {
-				if(!halresourcePath.endsWith(resourcePath)) {
-					throw new IllegalStateException();
-				}
 			}
 			
 			// get the entity name


### PR DESCRIPTION
1883357/1886870 - Remove the validation on self link from HALProvider. It is not mandatory to exclude self links from the body of a request nor have self links matching the requested resource. 
There is also nothing mentioned in the HAL specification document for links in HTTP requests.