### PR TITLE
Fix linkage parameters for embedded transitions

### DIFF
--- a/interaction-core/src/main/java/com/temenos/interaction/core/rim/SequentialResourceRequestHandler.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/rim/SequentialResourceRequestHandler.java
@@ -81,7 +81,7 @@ public class SequentialResourceRequestHandler implements ResourceRequestHandler 
 				
 				for (String key : transitionProperties.keySet()) {
 					if (transitionProperties.get(key) != null) {
-						newPathParameters.add(key, transitionProperties.get(key).toString());
+						newPathParameters.putSingle(key, transitionProperties.get(key).toString());
 					}
 				}				
 			}
@@ -97,7 +97,10 @@ public class SequentialResourceRequestHandler implements ResourceRequestHandler 
 				
 				for (String key : transitionProperties.keySet()) {
 					if (transitionProperties.get(key) != null) {
-						newQueryParameters.add(key, transitionProperties.get(key).toString());
+						/* Adding transition properties to both query parameters and path parameters,
+						 * as they should take priority over either */
+						newQueryParameters.putSingle(key, transitionProperties.get(key).toString());
+						newPathParameters.putSingle(key, transitionProperties.get(key).toString());
 					}
 				}
 			}


### PR DESCRIPTION
Issue #485 
Linkage parameters should be counted as both query and path parameters,
because we don't know which the target state will expect (since we don't
look at the URI pattern).
Linkage parameters should replace existing values, not accumulate with them
in the MultivaluedMap.