### PR TITLE
1932287 - Changes on hal provider

### DIFF
--- a/interaction-media-hal/src/main/java/com/temenos/interaction/media/hal/HALProvider.java
+++ b/interaction-media-hal/src/main/java/com/temenos/interaction/media/hal/HALProvider.java
@@ -77,6 +77,7 @@ import com.temenos.interaction.core.entity.EntityMetadata;
 import com.temenos.interaction.core.entity.EntityProperties;
 import com.temenos.interaction.core.entity.EntityProperty;
 import com.temenos.interaction.core.entity.Metadata;
+import com.temenos.interaction.core.entity.vocabulary.terms.TermMandatory;
 import com.temenos.interaction.core.hypermedia.DefaultResourceStateProvider;
 import com.temenos.interaction.core.hypermedia.Link;
 import com.temenos.interaction.core.hypermedia.MethodNotAllowedException;
@@ -360,11 +361,17 @@ public class HALProvider implements MessageBodyReader<RESTResource>, MessageBody
 					String simpleName = simpleOPropertyName(entityMetadata, property);
 					String qualifiedName = lengthenPrefix(prefix, simpleName);
 
-					if (entityMetadata.getPropertyVocabulary(qualifiedName) != null
-						&& property.getValue() != null) {
-						map.put(simpleName, buildFromOObject(entityMetadata,
-															 qualifiedName,
-															 property.getValue()));
+					if (entityMetadata.getPropertyVocabulary(qualifiedName) != null) {
+					    
+					    boolean mandatory = false;
+		                
+		                if(null!=entityMetadata.getPropertyVocabulary(qualifiedName).getTerm(TermMandatory.TERM_NAME)) {
+		                    mandatory = ((TermMandatory) entityMetadata.getPropertyVocabulary(qualifiedName).getTerm(TermMandatory.TERM_NAME)).isMandatory();
+		                }
+		                
+		                if(property.getValue() != null || mandatory) {
+		                    map.put(simpleName, buildFromOObject(entityMetadata, qualifiedName, property.getValue()));
+		                }
 					} else {
 						logger.debug(String.format("not adding property %s [%s], value %s",
 												   property.getName(), qualifiedName, property.getValue()));
@@ -373,7 +380,7 @@ public class HALProvider implements MessageBodyReader<RESTResource>, MessageBody
 				return map;
 			}
 		} else
-			return any.toString();
+			return any;
 	}
 
 	/** populate a Map with the properties of an OEntity
@@ -387,9 +394,16 @@ public class HALProvider implements MessageBodyReader<RESTResource>, MessageBody
 			// add properties if they are present on the resolved entity
 
 			String simpleName = simpleOPropertyName(entityMetadata, property);
-			if (entityMetadata.getPropertyVocabulary(simpleName) != null
-				&& property.getValue() != null) {
-				map.put(simpleName, buildFromOObject(entityMetadata, simpleName, property.getValue()));
+			if (entityMetadata.getPropertyVocabulary(simpleName) != null) {
+			    boolean mandatory = false;
+			    
+			    if(null!=entityMetadata.getPropertyVocabulary(simpleName).getTerm(TermMandatory.TERM_NAME)) {
+			        mandatory = ((TermMandatory) entityMetadata.getPropertyVocabulary(simpleName).getTerm(TermMandatory.TERM_NAME)).isMandatory();
+			    }
+
+			    if(property.getValue() != null || mandatory) {
+			        map.put(simpleName, buildFromOObject(entityMetadata, simpleName, property.getValue()));
+			    }
 			}
 			else {
 				logger.debug(String.format("not adding property %s, value %s",


### PR DESCRIPTION
**1932287:**
Remove the toString allows the provider to return the data type defined by the entity metadata

**Enhancement:**
If a field is marked as mandatory on IRIS metadata (TermMandatory = true) we should return the value, even if the value is a null object.