### PR TITLE
1999012

### DIFF
--- a/interaction-core/src/main/java/com/temenos/interaction/core/rim/HTTPHypermediaRIM.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/rim/HTTPHypermediaRIM.java
@@ -807,6 +807,11 @@ public class HTTPHypermediaRIM implements HTTPResourceInteractionModel {
                     break;
                 }
             }
+            
+            if (autoResponse.getRESTResource() != null) {
+                ctx.setResource(autoResponse.getRESTResource());
+            }
+            
             InteractionContext newCtx = new InteractionContext(ctx, headers, null, null, autoResponse.getResolvedState());
             newCtx.setResource(autoResponse.getRESTResource());
             autoTransitions = getTransitions(newCtx, autoResponse.getResolvedState(), Transition.AUTO);


### PR DESCRIPTION
Auto Transition fix: Set the current resource with the resource received from the auto transition.
During the auto transition if the resource sets in the correct context (auto transition) an entity, the entity must be passed to the next resource (can be used by the next resource)

Resource A {ctx.setResource(entity X)} --> resource B { filter = "parameterABC eq {X.parameterABC}" } 

