### PR TITLE
2018558 - Enable the Authorize button on Swagger UI

### DIFF
--- a/useragent-examples/useragent-swagger-ui/src/main/java/com/temenos/useragent/example/swagger/servlet/SwaggerServlet.java
+++ b/useragent-examples/useragent-swagger-ui/src/main/java/com/temenos/useragent/example/swagger/servlet/SwaggerServlet.java
@@ -43,14 +43,17 @@ public class SwaggerServlet extends HttpServlet {
     private static final long serialVersionUID = 8016912633666133628L;
 	private static final String SWAGGER_FILE_NAME = "api-docs.json";
 	private static String irisUrlMapping;
+	private static String apiKeyTokenName;
 	
 	public static final String SWAGGER_SERVLET_INIT_PARAM = "irisUrlMapping";
+	public static final String SWAGGER_SERVLET_APIKEY_PARAM = "apiKeyTokenName";
 	
 	@Override
 	public void init(ServletConfig config) throws ServletException {
 		super.init(config);
 		// Get the servlet-pattern from the IRIS servlet
 		irisUrlMapping = config.getInitParameter(SWAGGER_SERVLET_INIT_PARAM);
+		apiKeyTokenName = config.getInitParameter(SWAGGER_SERVLET_APIKEY_PARAM);
 	}
 
 	@Override
@@ -69,11 +72,18 @@ public class SwaggerServlet extends HttpServlet {
 			// Build a JsonReader object with the basePath and the data from api-docs.json in order to write it to the response
 			JsonObjectBuilder builder = Json.createObjectBuilder();
 			for (Entry<String, JsonValue> entry : jsonSwaggerObject.entrySet()) {
-				builder.add(entry.getKey(), entry.getValue());
+			    builder.add(entry.getKey(), entry.getValue());
 			}
 			
 			builder.add("basePath", req.getContextPath() + "/" + irisUrlMapping);
-			builder.add("host", req.getServerName() + ":" + req.getServerPort());
+			builder.add("host", req.getServerName() + ":" + req.getServerPort());	    
+		    JsonObject securityDefinitions = Json.createObjectBuilder()
+		            .add("api_key", Json.createObjectBuilder()
+		                .add("type", "apiKey")
+		                .add("name", (null != apiKeyTokenName && !StringUtils.isEmpty(apiKeyTokenName)) ? apiKeyTokenName : "api_key")
+		                .add("in", "header"))
+		            .build();
+		    builder.add("securityDefinitions", securityDefinitions);
 			
 			JsonObject jsonFinalSwaggerObject = builder.build();
 			JsonWriter jsonWriter = Json.createWriter(resp.getOutputStream());

--- a/useragent-examples/useragent-swagger-ui/src/test/java/com/temenos/useragent/example/swagger/SwaggerTest.java
+++ b/useragent-examples/useragent-swagger-ui/src/test/java/com/temenos/useragent/example/swagger/SwaggerTest.java
@@ -45,6 +45,8 @@ public class SwaggerTest {
 	
 	private static final String SWAGGER_SERVLET_INIT_PARAM_VALUE = "api";
 	
+	private static final String SWAGGER_SERVLET_APIKEY_PARAM_VALUE = "api_key_new";
+	
 	private static final String REQUEST_METHOD = "GET";
 	
 	private static final String REQUEST_URI = "swagger";
@@ -57,7 +59,7 @@ public class SwaggerTest {
 	
 	private static final int EXPECTED_SWAGGER_SERVLET_RESPONSE_STATUS = 200;
 	
-	private static final String EXPECTED_SWAGGER_SERVLET_SIMPLE_STATES_SWAGGER = "{\"apiVersion\":\"0.2\",\"swaggerVersion\":\"1.2\",\"resourcePath\":\"/A\",\"apis\":[{\"path\":\"/A\",\"operations\":[{\"method\":\"GET\",\"nickname\":\"A\"}]},{\"path\":\"/B\",\"operations\":[{\"method\":\"POST\",\"nickname\":\"B\"},{\"method\":\"GET\",\"nickname\":\"B\"}]}],\"basePath\":\""+ REQUEST_CONTEXT_PATH + "/" + SWAGGER_SERVLET_INIT_PARAM_VALUE + "\",\"host\":\""+REQUEST_SERVER_NAME + ":" + REQUEST_SERVER_PORT +"\"}";
+	private static final String EXPECTED_SWAGGER_SERVLET_SIMPLE_STATES_SWAGGER = "{\"apiVersion\":\"0.2\",\"swaggerVersion\":\"1.2\",\"resourcePath\":\"/A\",\"apis\":[{\"path\":\"/A\",\"operations\":[{\"method\":\"GET\",\"nickname\":\"A\"}]},{\"path\":\"/B\",\"operations\":[{\"method\":\"POST\",\"nickname\":\"B\"},{\"method\":\"GET\",\"nickname\":\"B\"}]}],\"basePath\":\""+ REQUEST_CONTEXT_PATH + "/" + SWAGGER_SERVLET_INIT_PARAM_VALUE + "\",\"host\":\""+REQUEST_SERVER_NAME + ":" + REQUEST_SERVER_PORT +"\",\"securityDefinitions\":{\"api_key\":{\"type\":\"apiKey\",\"name\":\"api_key_new\",\"in\":\"header\"}}}";
 
 	private static final DefaultResourceLoader defaultResourceLoader = new DefaultResourceLoader();
 	
@@ -73,6 +75,7 @@ public class SwaggerTest {
 		servletContext = new MockServletContext(defaultResourceLoader);
 		servletConfig = new MockServletConfig(servletContext, SWAGGER_SERVLET_NAME);
 		servletConfig.addInitParameter(SwaggerServlet.SWAGGER_SERVLET_INIT_PARAM, SWAGGER_SERVLET_INIT_PARAM_VALUE);
+		servletConfig.addInitParameter(SwaggerServlet.SWAGGER_SERVLET_APIKEY_PARAM, SWAGGER_SERVLET_APIKEY_PARAM_VALUE);
 		swaggerServlet = new SwaggerServlet();
 		swaggerServlet.init(servletConfig);
 	}


### PR DESCRIPTION
Added configurable api_key to the open API document to enable the Authorize menu on Swagger UI. (runtime test of the service on Swagger UI)
The api_key name can be configured the init-param on web.xml file of the container. If not defined the api_key name is setted to the default. Example:

```
    <servlet>
        <servlet-name>SwaggerServlet</servlet-name>
        <servlet-class>com.temenos.useragent.example.swagger.servlet.SwaggerServlet</servlet-class>
        <init-param>
            <param-name>irisUrlMapping</param-name>
            <param-value>Test.svc</param-value>
        </init-param>
        <init-param>
            <param-name>apiKeyTokenName</param-name>
            <param-value>mytokenname</param-value>
        </init-param>
        <load-on-startup>2</load-on-startup>
    </servlet>
```