### PR TITLE
Rtc 1999519

### DIFF
--- a/interaction-core/src/main/java/com/temenos/interaction/core/web/RequestContext.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/web/RequestContext.java
@@ -49,7 +49,7 @@ import java.util.Map;
 public final class RequestContext {
 
     public static final String HATEOAS_OPTIONS_HEADER = "x-jax-rs-hateoas-options";
-    
+
     private final static ThreadLocal<RequestContext> currentContext = new ThreadLocal<RequestContext>();
 
     public static void setRequestContext(RequestContext context) {
@@ -182,6 +182,16 @@ public final class RequestContext {
     	return this.userPrincipal;
     }
 
+    /**
+     * Returns all headers in Map.
+     *
+     * @return headers Map
+     */
+    public Map<String, List<String>> getAllHeaders() {
+        return headers;
+
+    }
+    
     /**
      * Returns header entries for the specified header name
      * using case sensitive search.

--- a/interaction-core/src/test/java/com/temenos/interaction/core/web/TestRequestContext.java
+++ b/interaction-core/src/test/java/com/temenos/interaction/core/web/TestRequestContext.java
@@ -115,6 +115,24 @@ public class TestRequestContext {
         assertEquals("value0", ctx.getFirstHeaderCaseInsensitive("HEADER0"));
         assertEquals("value0", ctx.getFirstHeaderCaseInsensitive("Header0"));
     }
+
+    @Test
+    public void testGetAllHeaders() {
+         Map<String, List<String>> headers = new HashMap<>();
+         List<String> lst1 = new ArrayList<>();
+         lst1.add("value0");
+         headers.put("header0", lst1);
+         List<String> lst2 = new ArrayList<>();
+         lst2.add("value1");
+         headers.put("header1", lst2);
+         
+         RequestContext ctx = new RequestContext("\basepath", "\requesturi", null, headers);
+
+         assertEquals(headers.size(), ctx.getAllHeaders().size());
+         assertEquals(headers, ctx.getAllHeaders());
+         assertEquals(headers.get("header0"), ctx.getAllHeaders().get("header0"));
+         assertEquals(headers.get("header1"), ctx.getAllHeaders().get("header1"));
+    }
     
     @Test
     public void testRequestTime() {

--- a/interaction-core/src/test/java/com/temenos/interaction/core/web/TestRequestContext.java
+++ b/interaction-core/src/test/java/com/temenos/interaction/core/web/TestRequestContext.java
@@ -129,7 +129,6 @@ public class TestRequestContext {
          RequestContext ctx = new RequestContext("\basepath", "\requesturi", null, headers);
 
          assertEquals(headers.size(), ctx.getAllHeaders().size());
-         assertEquals(headers, ctx.getAllHeaders());
          assertEquals(headers.get("header0").get(0), ctx.getAllHeaders().get("header0").get(0));
          assertEquals(headers.get("header1").get(0), ctx.getAllHeaders().get("header1").get(0));
     }

--- a/interaction-core/src/test/java/com/temenos/interaction/core/web/TestRequestContext.java
+++ b/interaction-core/src/test/java/com/temenos/interaction/core/web/TestRequestContext.java
@@ -130,8 +130,8 @@ public class TestRequestContext {
 
          assertEquals(headers.size(), ctx.getAllHeaders().size());
          assertEquals(headers, ctx.getAllHeaders());
-         assertEquals(headers.get("header0"), ctx.getAllHeaders().get("header0"));
-         assertEquals(headers.get("header1"), ctx.getAllHeaders().get("header1"));
+         assertEquals(headers.get("header0").get(0), ctx.getAllHeaders().get("header0").get(0));
+         assertEquals(headers.get("header1").get(0), ctx.getAllHeaders().get("header1").get(0));
     }
     
     @Test


### PR DESCRIPTION
Enhancement 1990960. The getAllHeaders() of RequestContext can be used to access headers which are provided in client request.
