### PR TITLE
RTC2038517 - Setting namespace used in EDMX document after model name is available

### DIFF
--- a/interaction-odata4j-ext/src/main/java/com/temenos/interaction/odataext/entity/MetadataOData4j.java
+++ b/interaction-odata4j-ext/src/main/java/com/temenos/interaction/odataext/entity/MetadataOData4j.java
@@ -396,8 +396,6 @@ public class MetadataOData4j {
 	 * @return
 	 */
 	public EdmDataServices createOData4jMetadata(Metadata metadata, ResourceStateMachine hypermediaEngine, ResourceState serviceDocument) {
-		String serviceName = metadata.getModelName();
-		String namespace = serviceName + Metadata.MODEL_SUFFIX;
 		Builder mdBuilder = EdmDataServices.newBuilder();
 		
 		mdBuilder.setVersion(odataVersion);
@@ -441,9 +439,12 @@ public class MetadataOData4j {
 				LOGGER.warn("Entity name '{}' does not have type. entityMetadata={}", state.getEntityName(), entityMetadata);
 			}
 		}
-					
-		// Add Navigation Properties
 		
+		//The model name is available after processing the states, i.e. the namespace should be created afterwards
+        String serviceName = metadata.getModelName();
+        String namespace = serviceName + Metadata.MODEL_SUFFIX;
+					
+		// Add Navigation Properties		
 		// build associations		
 		Map<EdmEntityType.Builder, Map<String, EdmAssociation.Builder>> entityTypeToStateAssociations = new HashMap<EdmEntityType.Builder, Map<String, EdmAssociation.Builder>>();
 		

--- a/interaction-odata4j-ext/src/test/resources/metadata-Customer.xml
+++ b/interaction-odata4j-ext/src/test/resources/metadata-Customer.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  interaction-core
+  %%
+  Copyright (C) 2012 - 2014 Temenos Holdings N.V.
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  #L%
+  -->
+        
+<Metadata ModelName="CustomerModelName" Version="1.0" 
+        xmlns="http://iris.temenos.com/metadata.xsd" 
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+        xsi:schemaLocation="http://iris.temenos.com metadata.xsd">
+    <Entity Name="Customer">
+        <Property Name="Id">
+            <Term Name="TERM_ID_FIELD">true</Term>
+        </Property>        
+    </Entity>
+</Metadata>

--- a/interaction-odata4j-ext/src/test/resources/metadataNoModelName.xml
+++ b/interaction-odata4j-ext/src/test/resources/metadataNoModelName.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  #%L
+  interaction-odata4j-ext
+  %%
+  Copyright (C) 2012 - 2013 Temenos Holdings N.V.
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  #L%
+  -->
+
+<Metadata Version="1.0" 
+          xmlns="http://iris.temenos.com/metadata.xsd"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://iris.temenos.com metadata.xsd">    
+	<Entity Name="EntityWithRestriction">
+		<Term Name="TEST_ENTITY_ALIAS">MyCustomer</Term>
+		<Property Name="name" >
+			<Term Name="TERM_ID_FIELD">true</Term>
+		</Property>
+		<Property Name="address">
+			<Term Name="TERM_LIST_TYPE">true</Term>
+			<Property Name="number">
+				<Term Name="TERM_VALUE_TYPE">INTEGER_NUMBER</Term>
+				<Term Name="TERM_RESTRICTION">displayOnly</Term>
+			</Property>
+			<Property Name="street">
+				<Term Name="TERM_LIST_TYPE">true</Term>
+				<Property Name="streetType">
+					<Term Name="TERM_RESTRICTION">displayonly</Term>
+				</Property>
+			</Property>
+			<Property Name="town">
+				<Term Name="TERM_RESTRICTION">filterOnly</Term>
+			</Property>
+			<Property Name="postCode">
+				<Term Name="TERM_RESTRICTION">filteronly</Term>
+			</Property>
+		</Property>
+		<Property Name="dateOfBirth" >
+			<Term Name="TERM_MANDATORY">true</Term>
+			<Term Name="TERM_VALUE_TYPE">TIMESTAMP</Term>
+		</Property>
+		<Property Name="sector">
+			<Term Name="TERM_RESTRICTION">displayOnly</Term>
+		</Property>
+		<Property Name="industry">
+			<Term Name="TERM_RESTRICTION">filterOnly</Term>
+		</Property>
+		<Property Name="loyal" >
+			<Term Name="TERM_VALUE_TYPE">BOOLEAN</Term>
+		</Property>
+		<Property Name="loyalty_rating" >
+			<Term Name="TERM_VALUE_TYPE">NUMBER</Term>
+		</Property>
+	</Entity>
+</Metadata>


### PR DESCRIPTION
The namespace used in the EDMX document (from $metadata) which includes the model name must be set/created after the metadata model name is made available. Prior to this change, namespace was set to nullModels as model name is not set when metadata is created using a resourceMetadataManager.
