### PR TITLE
Fix unit test failures with NPE for null properties

### DIFF
--- a/interaction-core/src/main/java/com/temenos/interaction/core/hypermedia/transition/EntityPropertiesGenerator.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/hypermedia/transition/EntityPropertiesGenerator.java
@@ -24,6 +24,7 @@ package com.temenos.interaction.core.hypermedia.transition;
 
 import com.temenos.interaction.core.hypermedia.Transformer;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -54,6 +55,10 @@ public class EntityPropertiesGenerator implements PropertiesGenerator {
         if (entity != null && transformer != null) {
             properties = transformer.transform(entity);
         }
-        return properties;
+        if (properties != null) {
+            return properties;
+        } else {
+            return Collections.emptyMap();
+        }
     }
 }


### PR DESCRIPTION
* EntityTransformer can return a null map of properties which, when merged into transition properties, results in NPE.