### PR TITLE
Location header updated only when resource state changed

### DIFF
--- a/interaction-core/src/main/java/com/temenos/interaction/core/rim/HTTPHypermediaRIM.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/rim/HTTPHypermediaRIM.java
@@ -688,7 +688,7 @@ public class HTTPHypermediaRIM implements HTTPResourceInteractionModel, Expressi
             responseBuilder = HeaderHelper.allowHeader(responseBuilder, interactions);
         } else if (status.getFamily() == Response.Status.Family.SUCCESSFUL) {
             if (resource != null) {
-                if (resource.getLinks() != null && !resource.getLinks().isEmpty()) {
+                if (resource.getLinks() != null && !resource.getLinks().isEmpty() && autoTransitioner != null && autoTransitioner.transition().isSuccessful()) {
                     responseBuilder = setLocationHeader(responseBuilder, resource.getLinks().iterator().next().getHref(), ctx.getQueryParameters());
                 }
 


### PR DESCRIPTION
* Only when resource state changed through auto transition should we update the http location
 header. Location header set and returned with 2xx status would mean the resource state
 has been changed and user agent might want to know about it.