### PR TITLE
Fix executing interaction commands for auto transitions

### DIFF
--- a/interaction-core/src/main/java/com/temenos/interaction/core/workflow/AbortOnErrorWorkflowStrategyCommand.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/workflow/AbortOnErrorWorkflowStrategyCommand.java
@@ -38,7 +38,7 @@ import com.temenos.interaction.core.command.InteractionException;
  */
 public class AbortOnErrorWorkflowStrategyCommand implements WorkflowCommand {
 
-	private List<InteractionCommand> commands = new ArrayList<InteractionCommand>();
+	protected List<InteractionCommand> commands = new ArrayList<InteractionCommand>();
 	
 	public AbortOnErrorWorkflowStrategyCommand() {}
 

--- a/interaction-core/src/main/java/com/temenos/interaction/core/workflow/InteractionWorkflowStrategyCommand.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/workflow/InteractionWorkflowStrategyCommand.java
@@ -37,13 +37,7 @@ import java.util.List;
  */
 public class InteractionWorkflowStrategyCommand extends AbortOnErrorWorkflowStrategyCommand {
 
-    private List<InteractionCommand> commands = new ArrayList<InteractionCommand>();
-
     public InteractionWorkflowStrategyCommand() {}
-
-    public boolean isEmpty() {
-        return commands.isEmpty();
-    }
 
     /**
      * Construct with a list of commands to execute.
@@ -60,9 +54,6 @@ public class InteractionWorkflowStrategyCommand extends AbortOnErrorWorkflowStra
             return;
         }
         super.addCommand(command);
-        if (command == null)
-            throw new IllegalArgumentException("No command supplied");
-        commands.add(command);
     }
 
 }


### PR DESCRIPTION
* All interaction commands in auto transitions are executed instead of
  only transition commands hence effectively bringing back the auto
  transition execution logic that was changed in the meantime to only
  support transition commands.

* With this change, any command implementing InteractionCommand would be
  executed as part of auto transition.