### PR TITLE
Fix to avoid double single quote

### DIFF
--- a/interaction-core/src/main/java/com/temenos/interaction/core/hypermedia/HypermediaTemplateHelper.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/hypermedia/HypermediaTemplateHelper.java
@@ -106,6 +106,16 @@ public class HypermediaTemplateHelper {
 						// replace template tokens
 					    String value = Matcher.quoteReplacement(normalizedProperties.get(param).toString());
 					    result = resolveWildCardMatches(result, value);
+                        /*
+                         * Avoid duplicate quotes, if both expression and value
+                         * contains single quotes. For example: Expression:
+                         * filter=FileVer eq '{Fv}' Value:Fv='SIM' Result should
+                         * be filter=FileVer eq 'SIM' instead filter=FileVer eq
+                         * ''SIM''
+                         */
+                        if (value.startsWith("'") && value.endsWith("'")) {
+                            result = result.replaceAll(Pattern.quote("'{" + param + "}'"), value);
+                        }
 					    result = result.replaceAll(Pattern.quote("{"+param+"}"), value);
 					}
 				}

--- a/interaction-core/src/test/java/com/temenos/interaction/core/hypermedia/TestHypermediaTemplateHelper.java
+++ b/interaction-core/src/test/java/com/temenos/interaction/core/hypermedia/TestHypermediaTemplateHelper.java
@@ -299,6 +299,14 @@ public class TestHypermediaTemplateHelper {
                 HypermediaTemplateHelper.templateReplace("Id eq {ArrOd}", properties));
     }
 
+	@Test
+    public void testQuoteValueReplace() {
+        Map<String, Object> properties = new HashMap<String, Object>();
+        properties.put("Fv", "'SIM'");
+        assertEquals("FileVer eq 'SIM'",
+                HypermediaTemplateHelper.templateReplace("FileVer eq '{Fv}'", properties));
+    }
+
 	private OComplexObject create(OProperty<?>... properties) {
 		List<OProperty<?>> propertyList = new ArrayList<OProperty<?>>();
 		for (OProperty<?> property : properties) {


### PR DESCRIPTION
- While template token replacement, if token is surrounded by single quotes and if value also contains single quotes, double single quotes exists after token replacement.
- For example: If value of Fv = 'SIM' then FileVersion = '{Fv}' become FileVersion=''SIM''
- This fix is to avoid double single quotes and resolve like FileVersion='SIM'