### PR TITLE
To resolve 201802 build issue updating equinox version to 3.8.0

### DIFF
--- a/interaction-dsl/com.temenos.interaction.rimdsl.parent/pom.xml
+++ b/interaction-dsl/com.temenos.interaction.rimdsl.parent/pom.xml
@@ -258,10 +258,23 @@
 					<artifactId>xtend-maven-plugin</artifactId>
 					<version>${xtend-version}</version>
 					<dependencies>
+						<!-- The following dependencies are appropriate for Xtend 2.13
+	                         (as used with ODL Parent 3.1.1) -->
+	                    <dependency>
+	                        <groupId>org.eclipse.jdt</groupId>
+	                        <artifactId>org.eclipse.jdt.core</artifactId>
+	                        <version>3.12.2</version>
+	                    </dependency>
+	                    <dependency>
+	                        <groupId>org.eclipse.platform</groupId>
+	                        <artifactId>org.eclipse.core.runtime</artifactId>
+	                        <version>3.12.0</version>
+	                    </dependency>
+                        <!-- Workaround for https://github.com/eclipse/xtext/issues/1231 -->
                         <dependency>
                             <groupId>org.eclipse.platform</groupId>
                             <artifactId>org.eclipse.equinox.common</artifactId>
-                            <version>3.10.0</version>
+                            <version>3.8.0</version>
                         </dependency>
                     </dependencies>
 					<configuration>


### PR DESCRIPTION
Since we are facing the below reported issue we tried the suggested solution but again that bump we always run into signature validation errors. so as suggested other solution in the defect ticket page https://github.com/eclipse/xtext/issues/1231 updating it