### PR TITLE
Trim standard port number while constructing relative url

### DIFF
--- a/interaction-core/src/main/java/com/temenos/interaction/core/hypermedia/Link.java
+++ b/interaction-core/src/main/java/com/temenos/interaction/core/hypermedia/Link.java
@@ -151,12 +151,15 @@ public class Link {
     }
     /**
      * Obtain the transition, i.e. the link relative to the REST service.
+     * {@link https://www.ietf.org/rfc/rfc1738.txt}
      * 
      * @param basePath  Path to REST service
      * @return relativePath of transition relative to REST service 
      */
     public String getRelativeHref(String basePath) {
-        String baseUri = HypermediaTemplateHelper.getTemplatedBaseUri(basePath, href);
+        // Trimming standard port number.
+        String baseUri = HypermediaTemplateHelper
+                .getTemplatedBaseUri(basePath.replaceFirst(":80/", "/").replaceFirst(":443/", "/"), href);
         StringBuffer regex = new StringBuffer("(?<=" + baseUri + ")\\S+");
         Pattern p = Pattern.compile(regex.toString());
         Matcher m = p.matcher(href);

--- a/interaction-core/src/test/java/com/temenos/interaction/core/hypermedia/TestLink.java
+++ b/interaction-core/src/test/java/com/temenos/interaction/core/hypermedia/TestLink.java
@@ -98,6 +98,26 @@ public class TestLink {
     }
     
     @Test
+    public void testGetRelativeHrefHttp() throws Exception {
+        Link link = new Link(null, "ServiceDocumentToEntitySet", "rel",
+                "http://portal3.xlb2.lo/tapt24-iris/tapt24.svc/LU0010001/FundsTransfer_FtTaps()/new", null, null, "GET",
+                null);
+        String relativeHref = link.getRelativeHref("http://portal3.xlb2.lo:80/tapt24-iris/tapt24.svc/{companyid}");
+        assertEquals("FundsTransfer_FtTaps()/new", relativeHref);
+
+    }
+
+    @Test
+    public void testGetRelativeHrefHttps() throws Exception {
+        Link link = new Link(null, "ServiceDocumentToEntitySet", "rel",
+                "https://portal3.xlb2.lo/tapt24-iris/tapt24.svc/LU0010001/FundsTransfer_FtTaps()/new", null, null,
+                "GET", null);
+        String relativeHref = link.getRelativeHref("https://portal3.xlb2.lo:443/tapt24-iris/tapt24.svc/{companyid}");
+        assertEquals("FundsTransfer_FtTaps()/new", relativeHref);
+
+    }
+
+    @Test
     public void testGetRelativeHref1() throws Exception {
         Link link = new Link(null, "ServiceDocumentToEntitySet", "rel", 
                 "http://example.com/boo/moo",


### PR DESCRIPTION
Trim standard port number while constructing relative url.
http://localhost:80/context to http://localhost/context
https://localhost:443/context to https://localhost/context